### PR TITLE
add byte size filter to dobjs returned for a station

### DIFF
--- a/pytools/icoscp/sparql/sparqls.py
+++ b/pytools/icoscp/sparql/sparqls.py
@@ -303,6 +303,7 @@ def stationData(station, level='2'):
                 ?spec rdfs:label ?specLabel .                
                 OPTIONAL {?dobj cpmeta:wasAcquiredBy/cpmeta:hasSamplingHeight ?samplingheight} .                                
 				?spec cpmeta:hasDataLevel ?datalevel .
+                ?dobj cpmeta:hasSizeInBytes ?bytes .
 				FILTER (?datalevel  %s)				
             }          """ % (station, level)
 


### PR DESCRIPTION
removes any unsuccesful submited dobjs where there is no actual data available. closing