### PR TITLE
Update icos_obs_vs_stilt_timeseries.ipynb

### DIFF
--- a/project_jupyter_notebooks/envrifair_winterschool/timeseries/icos_obs_vs_stilt_timeseries.ipynb
+++ b/project_jupyter_notebooks/envrifair_winterschool/timeseries/icos_obs_vs_stilt_timeseries.ipynb
@@ -66,7 +66,7 @@
     "|SVB|150|SVB150|Svartberget|\n",
     "|SMR|125|SMR125|Hyytiälä|\n",
     "|KIT|200|KIT200|Karlsruhe|\n",
-    "|LIN|99|LIN099|Lindenberg|"
+    "|LIN|98|LIN099|Lindenberg|"
    ]
   },
   {
@@ -158,7 +158,7 @@
    "source": [
     "#Call method to get a data object containing\n",
     "#data & metadata info for the selected data product:\n",
-    "dobj = Dobj('https://hdl.handle.net/11676/IM7PJYcuhiBpHtvEVuLhVk2M')\n"
+    "dobj = Dobj('11676/IM7PJYcuhiBpHtvEVuLhVk2M')"
    ]
   },
   {
@@ -463,6 +463,20 @@
     "#Assign standard deviation value to mid of month:\n",
     "myStation_monthly_std.index = myStation_monthly_std.index - pd.offsets.MonthBegin(1) + to_offset(pd.Timedelta(14, 'd'))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
fixed typo of LIN ICOS station sampling height (from 99 to 98)