### PR TITLE
TexLive2020

### DIFF
--- a/docker/icosbase/Dockerfile
+++ b/docker/icosbase/Dockerfile
@@ -21,7 +21,7 @@ RUN tar -xf /tmp/install-tl-unx.tar.gz --strip-components=1 -C /tmp/
 
 # add profile and start intallation
 
-COPY exploredata/Texlive2020/texlive.profile /tmp/.
+COPY Texlive2020/texlive.profile /tmp/.
 RUN /tmp/install-tl --profile=/tmp/texlive.profile
 
 # export path to texlive2020
@@ -54,7 +54,7 @@ RUN jupyter nbextensions_configurator enable
 # such that headers are NOT numbered by default
 # and activate the extension
 
-COPY exploredata/nbextensionDefault/*.diff /tmp/
+COPY nbextensionDefault/*.diff /tmp/
 RUN patch /opt/conda/share/jupyter/nbextensions/toc2/toc2.yaml /tmp/toc2.yaml.diff
 RUN patch /opt/conda/share/jupyter/nbextensions/toc2/toc2.js /tmp/toc2.js.diff
 RUN jupyter nbextension enable toc2/main

--- a/docker/icosbase/Dockerfile
+++ b/docker/icosbase/Dockerfile
@@ -1,7 +1,36 @@
 # We use a specific hash since :latest has broken spuriously in the past.
 # https://hub.docker.com/r/jupyter/datascience-notebook
-# This hash is jupyter/datascience-notebook:latest on 2021-01-20.
-FROM jupyter/datascience-notebook@sha256:ed6c44b7b513783e541e251fa057ced63e91887179c16ae5c535fe103c86c3f4
+# This hash is jupyter/datascience-notebook:latest on 2021-01-28.
+FROM jupyter/datascience-notebook@sha256:e6d5c7d595d25f6ec7a894d8fcc7cb4b542c28f65fb71cdf0cb9b77f0ce0ddd0
+
+# -------------------------
+# this block is added to the top of the Dockerfile
+# because it takes about 45 minutes to install TL2020, so be patient.
+# Install a full version of Texlive2020 (https://tug.org/texlive/)
+# switch to root for texlive installation
+USER root
+
+# Remove old texlive installation
+RUN rm -rf /usr/share/texlive
+
+# Add texlive2020 installer and unpack
+# http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+
+RUN wget -O /tmp/install-tl-unx.tar.gz http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+RUN tar -xf /tmp/install-tl-unx.tar.gz --strip-components=1 -C /tmp/
+
+# add profile and start intallation
+
+COPY exploredata/Texlive2020/texlive.profile /tmp/.
+RUN /tmp/install-tl --profile=/tmp/texlive.profile
+
+# export path to texlive2020
+ENV PATH="/usr/local/texlive/2020/bin/x86_64-linux:${PATH}"
+
+# switch back to normal user
+USER jovyan
+
+# -------------------------
 
 # Experimental, use mamba.
 # https://medium.com/@QuantStack/open-software-packaging-for-science-61cecee7fc23
@@ -25,20 +54,21 @@ RUN jupyter nbextensions_configurator enable
 # such that headers are NOT numbered by default
 # and activate the extension
 
-COPY nbextensionDefault/*.diff /tmp/
+COPY exploredata/nbextensionDefault/*.diff /tmp/
 RUN patch /opt/conda/share/jupyter/nbextensions/toc2/toc2.yaml /tmp/toc2.yaml.diff
 RUN patch /opt/conda/share/jupyter/nbextensions/toc2/toc2.js /tmp/toc2.js.diff
 RUN jupyter nbextension enable toc2/main
 
+# update jupyter lab and rebuild
+RUN jupyter labextension install @jupyterlab/debugger --no-build
+RUN jupyter labextension install @lckr/jupyterlab_variableinspector --no-build
+# jupter lab build fails with this base-notebook
+#RUN jupyter labextension install qgrid2 --no-build
+RUN jupyter lab build
 
 RUN pip install pangaeapy
 RUN pip install jupyter_module_loader
 
-# update jupyter lab and rebuild
-RUN jupyter labextension install @jupyterlab/debugger --no-build
-RUN jupyter labextension install @lckr/jupyterlab_variableinspector --no-build
-RUN jupyter labextension install qgrid2 --no-build
-RUN jupyter lab build
 
 WORKDIR /home/jovyan
 

--- a/docker/icosbase/Texlive2020/texlive.profile
+++ b/docker/icosbase/Texlive2020/texlive.profile
@@ -1,0 +1,30 @@
+# texlive.profile written on Wed Feb  3 23:24:27 2021 UTC
+# It will NOT be updated and reflects only the
+# installation profile at installation time.
+selected_scheme scheme-full
+TEXDIR /usr/local/texlive/2020
+TEXMFCONFIG ~/.texlive2020/texmf-config
+TEXMFHOME ~/texmf
+TEXMFLOCAL /usr/local/texlive/texmf-local
+TEXMFSYSCONFIG /usr/local/texlive/2020/texmf-config
+TEXMFSYSVAR /usr/local/texlive/2020/texmf-var
+TEXMFVAR ~/.texlive2020/texmf-var
+binary_x86_64-linux 1
+instopt_adjustpath 1
+instopt_adjustrepo 1
+instopt_letter 0
+instopt_portable 0
+instopt_write18_restricted 1
+tlpdbopt_autobackup 1
+tlpdbopt_backupdir tlpkg/backups
+tlpdbopt_create_formats 1
+tlpdbopt_desktop_integration 1
+tlpdbopt_file_assocs 1
+tlpdbopt_generate_updmap 0
+tlpdbopt_install_docfiles 1
+tlpdbopt_install_srcfiles 1
+tlpdbopt_post_code 1
+tlpdbopt_sys_bin /usr/local/bin
+tlpdbopt_sys_info /usr/local/info
+tlpdbopt_sys_man /usr/local/man
+tlpdbopt_w32_multi_user 1


### PR DESCRIPTION
update dockerfile, icos base image for jupyter hub, exploretes, exploredata
- remove TL2019
- switch to full installation of Texlive2020
