### PR TITLE
Update Dockerfile exploredata

### DIFF
--- a/docker/exploredata/Dockerfile
+++ b/docker/exploredata/Dockerfile
@@ -1,6 +1,22 @@
 ARG BASE=icosbase
 FROM $BASE
 
+# -----start temp fix-----------------------------------
+
+# temporary fixes to the icos base image
+# current verion of jupyter/datascience-notebook
+
+# has updated version of pandas which needs openpyxl to read excel files
+RUN mamba install -qy openpyxl
+
+# gdal 3.2.1 can't be loaded.. downgrade to last version we 
+# know is working
+
+RUN mamba install -qy gdal=3.1.4
+
+# -----eof temp fix------------------------------------
+
+
 # 1000:100 is jovyan:users
 ADD --chown=1000:100 education ./education
 ADD --chown=1000:100 icos_jupyter_notebooks ./icos_jupyter_notebooks


### PR DESCRIPTION
fix for pandas requirement, change to use openpyxl to read excel files (package not installed in jupyter/scientific notebook image
- install openpyxl

Downgrade gdal from 3.2.1 to 3.1.4
