### PR TITLE
fixes issue #73

### DIFF
--- a/notebooks/icos_jupyter_notebooks/station_characterization/stc_functions.py
+++ b/notebooks/icos_jupyter_notebooks/station_characterization/stc_functions.py
@@ -894,7 +894,9 @@ def seasonal_table(myStation):
         years=[int(year) for year in available_STILT['years']]
         
         if year_before in years:
-            months_year_before = available_STILT[year_before]['months'] 
+            try:
+                months_year_before = available_STILT[year_before]['months'] 
+            except: months_year_before=''
         else:
             months_year_before=''
 


### PR DESCRIPTION
In the settings used to produce error #73 , the station actually has some footprints for year 2006 (despite key-error). No months are listed for 2006. Could look into why the created stilt dictionary (found in the object for each station characterization run under .settings['stilt']) has it as an available year but not month.