### PR TITLE
PUI084 and SMR125 as opposed to PUI and SMR127

### DIFF
--- a/notebooks/icos_jupyter_notebooks/network_characterization/gui_network_characterization.py
+++ b/notebooks/icos_jupyter_notebooks/network_characterization/gui_network_characterization.py
@@ -134,7 +134,7 @@ def use_icos_network_change(c):
                             
         """
         
-        list_icos_stations_reduced = ['BIR075','GAT344', 'HEL110', 'HPB131','HTM150', 'UTO','IPR100', 'JFJ','JUE120','KIT200','KRE250','LMP','LIN099','LUT','CMN760','NOR100','OPE120','OXK163','PAL','PRS','PUI','PUY','SMR127','SAC100','STE252','SVB150','TOH147','TRN180','WES','WAO','ZSF']
+        list_icos_stations_reduced = ['BIR075','GAT344', 'HEL110', 'HPB131','HTM150', 'UTO','IPR100', 'JFJ','JUE120','KIT200','KRE250','LMP','LIN099','LUT','CMN760','NOR100','OPE120','OXK163','PAL','PRS','PUI084','PUY','SMR125','SAC100','STE252','SVB150','TOH147','TRN180','WES','WAO','ZSF']
 
         sites_base_network_options.value = list_icos_stations_reduced
 


### PR DESCRIPTION
The slight update to the list of stations (STILT codes) that are selected when the user chooses "use current ICOS network" in the network characterization tools. It is the same list of stations that have station characterization documents. In the STILT viewer, it is the stations that are marked as "ICOS stations" with the highest inlet height. For now, it is a static list. Once station_info that links station heights with model heights (and STILT names) is implemented in the Python library the list of STILT station codes should come from here. 

@ZogopZ this can now be deployed. I updated from master before publishing the branch. 