### PR TITLE
is name matches for grass/shrubland in aggregated country bar graph

### DIFF
--- a/notebooks/icos_jupyter_notebooks/network_characterization/network_characterization_functions.py
+++ b/notebooks/icos_jupyter_notebooks/network_characterization/network_characterization_functions.py
@@ -802,7 +802,7 @@ def land_cover_bar_graphs_base(networkObj):
     dictionary = networkObj.countryDict
   
     # for the graph with all countries 
-    land_cover_values = ['Broad leaf forest', 'Coniferous forest', 'Mixed forest', 'Cropland', 'Pasture', 'Urban', 'Ocean', 'Grass/shrub', 'Other', 'Unknown']
+    land_cover_values = ['Broad leaf forest', 'Coniferous forest', 'Mixed forest', 'Cropland', 'Pasture', 'Urban', 'Ocean', 'Grass/shrubland', 'Other', 'Unknown']
     
     colors = ['#4c9c5e','#CAE0AB','#90C987', '#521A13', '#F7F056', '#DC050C', '#1964B0', '#F1932D', '#882E72','#777777']
     


### PR DESCRIPTION
Small update to the bar graphs showing the land cover breakdown within all selected countries. Previously the "Grass/Shrubland" slice did not show up. It has always showed up in the bar graphs for the individual countries though. 

@ZogopZ , if the changes can be deployed soon that would be nice. 