### PR TITLE
uk check ICOS & CO2 data availability for RINGO notebooks

### DIFF
--- a/docker/exploredata/Dockerfile
+++ b/docker/exploredata/Dockerfile
@@ -12,6 +12,9 @@ ADD --chown=1000:100 pylib_examples ./pylib_examples
 ADD --chown=1000:100 *.md ./
 ADD --chown=1000:100 *.ipynb ./
 
-# The index notebook has an initialisation cell. To automatically run
-# the notebook we need to trust it first.
+# The index and other notebooks have an initialization cell. To automatically
+# run these notebooks we need to trust them first. This also prevents the
+# trust notebook popup window from showing up.
 RUN jupyter trust index_notebook.ipynb
+RUN jupyter trust project_jupyter_notebooks/RINGO_T1.3/ICOS_flasksampling_fossilfuel.ipynb
+RUN jupyter trust project_jupyter_notebooks/RINGO_T1.3/RINGO_T1.3_flasksampling_v5.ipynb

--- a/notebooks/project_jupyter_notebooks/RINGO_T1.3/ICOS_flasksampling_fossilfuel.ipynb
+++ b/notebooks/project_jupyter_notebooks/RINGO_T1.3/ICOS_flasksampling_fossilfuel.ipynb
@@ -61,8 +61,6 @@
     "        - select sampling time, e.g. 13:00 local time (12 UTC) \n",
     "  \n",
     "\n",
-    "### <font color='red'> First step: run 'Restart & Run All' from the 'Kernel' dropdown.</font>\n",
-    "\n",
     "<br>\n"
    ]
   },
@@ -80,9 +78,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 1,
+   "metadata": {
+    "init_cell": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Plots are stored in:  /home/jovyan/output/flasksampling\n"
+     ]
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
+       "    return false;\n",
+       "}\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Import functions used in this notebook from the Jupyter Notebook flasksampling_modules.ipynb\n",
     "%run ./modules/flasksampling_modules_ff.ipynb\n"
@@ -101,6 +123,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "init_cell": true,
     "scrolled": true
    },
    "outputs": [],
@@ -123,6 +146,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "init_cell": true,
     "scrolled": true
    },
    "outputs": [],
@@ -130,16 +154,10 @@
     "#Call function to present widget:\n",
     "create_widget_selection_ff()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
+  "celltoolbar": "Initialization Cell",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -173,7 +191,7 @@
     "width": "299px"
    },
    "toc_section_display": true,
-   "toc_window_display": true
+   "toc_window_display": false
   }
  },
  "nbformat": 4,

--- a/notebooks/project_jupyter_notebooks/RINGO_T1.3/README.ipynb
+++ b/notebooks/project_jupyter_notebooks/RINGO_T1.3/README.ipynb
@@ -13,7 +13,7 @@
     "<br>\n",
     "\n",
     "# ICOS Project-specific Jupyter Notebooks - RINGO T1.3\n",
-    "This folder includes notebooks and ancillary data files for presenting an evaluation of different sampling strategies related to the RINGO project. The notebook supports the analysis presented in Levin et al., A dedicated flask sampling strategy developed for ICOS stations based on CO2 and CO measurements and STILT footprint modelling, Atmos. Chem. Phys., https://doi.org/10.5194/acp-2020-185, 2020.\n",
+    "This folder includes notebooks and ancillary data files for presenting an evaluation of different sampling strategies related to the RINGO project. The notebook supports the analysis presented in Levin et al., A dedicated flask sampling strategy developed for Integrated Carbon Observation System (ICOS) stations based on CO2 and CO measurements and Stochastic Time-Inverted Lagrangian Transport (STILT) footprint modelling, Atmos. Chem. Phys., 20, 11161–11180, https://doi.org/10.5194/acp-20-11161-2020, 2020.\n",
     "\n",
     "<br>\n",
     "\n",
@@ -22,9 +22,12 @@
     "\n",
     "* Jupyter Notebook for evaluation of flask sampling strategies for (1) quality control for in situ observations, (2) representative information on atmospheric components currently not monitored in situ at the stations, (3) samples for 14CO2 analysis that are significantly influenced by fossil fuel CO2 (ffCO2) emission areas. Evaluation of sampling strategies is based on STILT footprints (part 1) and ICOS measurement data (part 2). \n",
     "\n",
+    "* Jupyter notebook for selecting an appropriate CO-offset threshold to identify events with potentially high fossil fuel CO2 contribution for ICOS measurement time series (ICOS release and NRT) for all ICOS atmospheric stations.\n",
+    "\n",
     "* modules folder (contains Python scripts to handle STILT footprints)\n",
-    "* Figures folder (contains resulting output)\n",
+    "\n",
     "* majorCitiesEurope.xlsx (contains list of major cities in Europe)\n",
+    "\n",
     "* logos folder (contains RINGO logo)\n",
     "\n",
     "<br>\n",
@@ -33,6 +36,14 @@
     "This work is licensed under a Creative Commons Attribution 4.0 International License (CC BY 4.0). <br>\n",
     "Copyright © 2019-2020 ICOS ERIC\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "expressed-explosion",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/project_jupyter_notebooks/RINGO_T1.3/README.md
+++ b/notebooks/project_jupyter_notebooks/RINGO_T1.3/README.md
@@ -4,7 +4,7 @@
 <br> 
 
 # ICOS Project-specific Jupyter Notebooks - RINGO T1.3
-This folder includes notebooks and ancillary data files for presenting an evaluation of different sampling strategies related to the RINGO project. The notebook supports the analysis presented in Levin et al., A dedicated flask sampling strategy developed for ICOS stations based on CO2 and CO measurements and STILT footprint modelling, Atmos. Chem. Phys., https://doi.org/10.5194/acp-2020-185, 2020.
+This folder includes notebooks and ancillary data files for presenting an evaluation of different sampling strategies related to the RINGO project. The notebook supports the analysis presented in Levin et al., A dedicated flask sampling strategy developed for Integrated Carbon Observation System (ICOS) stations based on CO2 and CO measurements and Stochastic Time-Inverted Lagrangian Transport (STILT) footprint modelling, Atmos. Chem. Phys., 20, 11161–11180, https://doi.org/10.5194/acp-20-11161-2020, 2020.
 
 <br>
 
@@ -13,9 +13,12 @@ The folder is divided into the following parts:
 
 * Jupyter Notebook for evaluation of flask sampling strategies for (1) quality control for in situ observations, (2) representative information on atmospheric components currently not monitored in situ at the stations, (3) samples for 14CO2 analysis that are significantly influenced by fossil fuel CO2 (ffCO2) emission areas. Evaluation of sampling strategies is based on STILT footprints (part 1) and ICOS measurement data (part 2). 
 
+* Jupyter notebook for selecting an appropriate CO-offset threshold to identify events with potentially high fossil fuel CO2 contribution for ICOS measurement time series (ICOS release and NRT) for all ICOS atmospheric stations.
+
 * modules folder (contains Python scripts to handle STILT footprints)
-* Figures folder (contains resulting output)
+
 * majorCitiesEurope.xlsx (contains list of major cities in Europe)
+
 * logos folder (contains RINGO logo)
 
 <br>

--- a/notebooks/project_jupyter_notebooks/RINGO_T1.3/RINGO_T1.3_flasksampling_v5.ipynb
+++ b/notebooks/project_jupyter_notebooks/RINGO_T1.3/RINGO_T1.3_flasksampling_v5.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "The notebook supports the analysis presented in the paper:\n",
     "\n",
-    "<b> A dedicated flask sampling strategy developed for ICOS stations based on CO2 and CO measurements and STILT footprint modelling </b>\n",
+    "<b> A dedicated flask sampling strategy developed for Integrated Carbon Observation System (ICOS) stations based on CO2 and CO measurements and Stochastic Time-Inverted Lagrangian Transport (STILT) footprint modelling </b>\n",
     "\n",
     "Ingeborg Levin, Ute Karstens, Markus Eritt, Fabian Maier, Sabrina Arnold, Daniel Rzesanke, Samuel Hammer, Michel Ramonet, Gabriela Vítková, Sebastien Conil, Michal Heliasz, Dagmar Kubistin, and Matthias Lindauer\n",
     "\n",
@@ -30,7 +30,7 @@
     "\n",
     "In situ CO2 and CO measurements from five atmospheric ICOS (Integrated Carbon Observation System) stations have been analysed together with footprint model runs from the regional transport model STILT, to develop a dedicated strategy for flask sampling with an automated sampler. Flask sampling in ICOS has three different purposes: (1) Provide an independent quality control for in situ observations, (2) provide representative information on atmospheric components currently not monitored in situ at the stations, (3) collect samples for 14CO2 analysis that are significantly influenced by fossil fuel CO2 (ffCO2) emission areas. Based on the existing data and experimental results obtained at the Heidelberg pilot station with a prototype flask sampler, we suggest that single flask samples should be collected regularly every third day around noon/afternoon from the highest level of a tower station. Air samples shall be collected over one hour with equal temporal weighting to obtain a true hourly mean. At all stations studied, more than 50 % of flasks to be collected around mid-day will likely be sampled during low ambient variability (< 0.5 ppm standard deviation of one-minute values). Based on a first application at the Hohenpeißenberg ICOS site, such flask data are principally suitable to detect CO2 concentration biases larger than 0.1 ppm with a one-sigma confidence level between flask and in situ observations from only 5 flask comparisons. In order to have a maximum chance to also sample ffCO2 emission areas, additional flasks need to be collected on all other days in the afternoon. Using the continuous in situ CO observations, the CO deviation from an estimated background value must be determined the day after each flask sampling and, depending on this offset, an automated decision must be made if a flask shall be retained for 14CO2 analysis. It turned out that, based on existing data, ffCO2 events of more than 4–5 ppm will be very rare at all stations studied, particularly in summer. During the other seasons, events could be collected more frequently. The strategy developed in this project is currently being implemented at the ICOS stations.\n",
     "\n",
-    "Atmos. Chem. Phys., https://doi.org/10.5194/acp-2020-185, accepted, 2020\n"
+    "Atmos. Chem. Phys., 20, 11161–11180, https://doi.org/10.5194/acp-20-11161-2020, 2020.\n"
    ]
   },
   {
@@ -113,9 +113,6 @@
     "    \n",
     "<br>\n",
     "\n",
-    "### <font color='red'> Please run 'Restart & Run All' from the 'Kernel' dropdown first .</font>\n",
-    "\n",
-    "<br>\n",
     "\n",
     "###  [Click here to directly go to the analysis of STILT and ICOS observation time series  ](#Selection)\n",
     "\n",
@@ -138,77 +135,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
-       "    return false;\n",
-       "}\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "init_cell": true
+   },
+   "outputs": [],
    "source": [
     "# Import functions used in this notebook from the Jupyter Notebook flasksampling_modules.ipynb\n",
     "\n",
     "%run ./modules/flasksampling_modules.ipynb\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[1mFunctions loaded:\u001b[0;0m\n",
-      "all_selection_plots\n",
-      "atc_station_tracer_query\n",
-      "clear_output\n",
-      "create_STILT_dictionary\n",
-      "create_widget_selection\n",
-      "create_widget_selection_icos\n",
-      "display\n",
-      "get_bigCities\n",
-      "lonlat_2_ixjy\n",
-      "plot_comparison\n",
-      "plot_footprints\n",
-      "plot_icos_stilt_timeseries\n",
-      "plot_icos_ts_selection\n",
-      "plot_stilt_ts_selection\n",
-      "print_STILT_dictionary\n",
-      "read_emissions\n",
-      "read_icos_data\n",
-      "read_stilt_timeseries_RINGO_T13\n",
-      "run_all\n",
-      "run_obs\n",
-      "sensitivity_selection_icos\n"
-     ]
-    }
-   ],
-   "source": [
-    "# list all loaded user-defined functions\n",
-    "func = %who_ls function\n",
-    "print (\"\\033[1m\" + \"Functions loaded:\" + \"\\033[0;0m\")\n",
-    "for mm in func:\n",
-    "    print (mm)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "[Back to top](#Top)"
    ]
   },
   {
@@ -222,26 +157,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
+    "init_cell": true,
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d46ef3e2d2d54585a6988c7539ca3f55",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#Call function to present widget:\n",
     "create_widget_selection()"
@@ -272,24 +193,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "33a28bfc087f4d0d8c796f517c81ef78",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "init_cell": true
+   },
+   "outputs": [],
    "source": [
     "#Call function to present widget:\n",
     "create_widget_selection_icos()"
@@ -311,6 +219,7 @@
   }
  ],
  "metadata": {
+  "celltoolbar": "Initialization Cell",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -326,7 +235,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.4"
+   "version": "3.8.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": false,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,

--- a/notebooks/project_jupyter_notebooks/RINGO_T1.3/modules/README.ipynb
+++ b/notebooks/project_jupyter_notebooks/RINGO_T1.3/modules/README.ipynb
@@ -16,9 +16,11 @@
     "\n",
     "<br>\n",
     "\n",
-    "The folder contains python modules for the RINGO_T1.3_flasksampling notebook:\n",
+    "The folder contains python modules for the RINGO T1.3 flasksampling notebooks:\n",
     "\n",
     "* flasksampling_modules.ipynb notebook contains routines for the analysis of STILT results together with ICOS measurement timeseries to evaluate different parameters for the flask sampling strategy\n",
+    "\n",
+    "* flasksampling_modules_ff.ipynb notebook contains routines for the analysis ICOS measurement timeseries to evaluate thresholds for the flask sampling strategy\n",
     "\n",
     "* STILT_modules_plus.py contains STILT-specific python routines plus a routine to read ICOS atmospheric measurement data\n",
     "\n",
@@ -30,6 +32,14 @@
     "This work is licensed under a Creative Commons Attribution 4.0 International License (CC BY 4.0). <br>\n",
     "Copyright © 2019-2020 ICOS ERIC"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "compressed-blackjack",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/project_jupyter_notebooks/RINGO_T1.3/modules/README.md
+++ b/notebooks/project_jupyter_notebooks/RINGO_T1.3/modules/README.md
@@ -7,9 +7,11 @@
 
 <br>
 
-The folder contains python modules for the RINGO_T1.3_flasksampling notebook:
+The folder contains python modules for the RINGO T1.3 flasksampling notebooks:
 
 * flasksampling_modules.ipynb notebook contains routines for the analysis of STILT results together with ICOS measurement timeseries to evaluate different parameters for the flask sampling strategy
+
+* flasksampling_modules_ff.ipynb notebook contains routines for the analysis ICOS measurement timeseries to evaluate thresholds for the flask sampling strategy
 
 * STILT_modules_plus.py contains STILT-specific python routines plus a routine to read ICOS atmospheric measurement data
 

--- a/notebooks/project_jupyter_notebooks/RINGO_T1.3/modules/STILT_modules_plus.py
+++ b/notebooks/project_jupyter_notebooks/RINGO_T1.3/modules/STILT_modules_plus.py
@@ -24,7 +24,7 @@ from icoscp.sparql import sparqls
 
 
 my_home = os.getenv('HOME')
-sys.path.insert(0,my_home+'/new_jupyter/modules')
+#sys.path.insert(0,my_home+'/common/project_jupyter_notebooks/RINGO_T1.3/modules')
 from extra_sparqls import get_station_class, get_icos_stations_atc_samplingheight #, atc_station_tracer_query
 
 # paths --- changed for new JupyterHub instance

--- a/notebooks/project_jupyter_notebooks/RINGO_T1.3/modules/flasksampling_modules_ff.ipynb
+++ b/notebooks/project_jupyter_notebooks/RINGO_T1.3/modules/flasksampling_modules_ff.ipynb
@@ -2118,10 +2118,12 @@
     "    rows = []\n",
     "    for i in range(np.size(atm_stations_list.id)):\n",
     "        this_station = icos_station.get(atm_stations_list.id.values[i]).data()\n",
-    "        sh = np.max([float(j) for j in this_station.loc[this_station.specLabel.str.contains('CO2')].samplingheight.values if j!=''])\n",
-    "        rows.append([atm_stations_list.id.values[i],atm_stations_list.name.values[i],\n",
-    "                     sh,atm_stations_list.name.values[i]+'  '+str(int(sh))+'m'])\n",
-    "\n",
+    "        try:\n",
+    "            sh = np.max([float(j) for j in this_station.loc[this_station.specLabel.str.contains('CO2')].samplingheight.values if j!=''])\n",
+    "            rows.append([atm_stations_list.id.values[i],atm_stations_list.name.values[i],\n",
+    "                         sh,atm_stations_list.name.values[i]+'  '+str(int(sh))+'m'])\n",
+    "        except:\n",
+    "            pass\n",
     "    df = pd.DataFrame(rows, columns=[\"id\", \"name\", \"samplingheight\",\"widget_text\"])\n",
     "    return df"
    ]


### PR DESCRIPTION
- ICOS_flasksampling_fossilfuel.ipynb: don't list ICOS station in dropdown if CO2 data don't exist
- Use nbextension initialization cells in ringo notebooks
    - Trust notebooks using initialization cells in `jupyter/docker/exploredata/Dockerfile`. This will prevent the `trust notebook` popup when opening these notebooks.
- Update README files (solves issue #125)