### PR TITLE
update to exported settings file

### DIFF
--- a/notebooks/icos_jupyter_notebooks/station_characterization/stc_functions.py
+++ b/notebooks/icos_jupyter_notebooks/station_characterization/stc_functions.py
@@ -1538,7 +1538,13 @@ def save(stc, fmt='pdf'):
     # save settings as json file
     file = os.path.join(stc.settings['output_folder'],'settings.json')
     with open(file, 'w') as f:
-        json.dump(stc.settings, f, indent=4)
+        
+        settings_copy = stc.settings.copy()
+        
+        del settings_copy['icos']
+        del settings_copy['stilt']
+        
+        json.dump(settings_copy, f, indent=4)
         
     # save PDF
     tex_string=tex.generate_full(stc)


### PR DESCRIPTION
saved settings file to be uploaded to re-create the station characterization run. Needed to make it a copy since the stc objects settings are also passed to the function that creates the .tex (and in turn .pdf) file. Information in stc,settings that are removed here are used there.

closes #212 