### PR TITLE
bars in correct direction (land cover polar)

### DIFF
--- a/notebooks/icos_jupyter_notebooks/station_characterization/gui.py
+++ b/notebooks/icos_jupyter_notebooks/station_characterization/gui.py
@@ -451,7 +451,7 @@ time_selection= SelectMultiple(
     disabled=False)
 
 
-bin_size = Dropdown(options = [15, 30, 60, 90, 180, 360],
+bin_size = Dropdown(options = [15, 30, 45, 60, 90, 180, 360],
             description = 'Bin size (degrees)', style=style_bin,
             disabled = False,)
 

--- a/notebooks/icos_jupyter_notebooks/station_characterization/stc_functions.py
+++ b/notebooks/icos_jupyter_notebooks/station_characterization/stc_functions.py
@@ -1110,6 +1110,7 @@ def land_cover_polar_graph(myStation):
     rosedata= rosedata.applymap(lambda x: x / total_all * 100)
        
     directions = np.arange(0, 360, bin_size)
+    directions = np.arange(dir_bins[1], 360, bin_size)
     
     if title=='yes':
         

--- a/notebooks/icos_jupyter_notebooks/station_characterization/stc_functions.py
+++ b/notebooks/icos_jupyter_notebooks/station_characterization/stc_functions.py
@@ -1108,8 +1108,7 @@ def land_cover_polar_graph(myStation):
     total_all=sum(rosedata_sum_per_class_sorted)
     #for all values: want the % of the total sensitivity (one value for each distance for each direction)
     rosedata= rosedata.applymap(lambda x: x / total_all * 100)
-       
-    directions = np.arange(0, 360, bin_size)
+
     directions = np.arange(dir_bins[1], 360, bin_size)
     
     if title=='yes':


### PR DESCRIPTION
direction was slightly shifted before. barely noticeable for the 15 degree bins (which we have in the stc documents), but for 180 degree bin it was shifted by 90 degrees (shifting half of the bin size).

@ukarst , I found this bug while working with the settings problem today.
@claudiodonofrio , I am pushing a change for the radiocarbon notebook in a bit (discussed with Ute already), so maybe hold off with updating the jupyter hub. 