### PR TITLE
PDF and into text when siteType == None

### DIFF
--- a/notebooks/icos_jupyter_notebooks/station_characterization/gui.py
+++ b/notebooks/icos_jupyter_notebooks/station_characterization/gui.py
@@ -293,13 +293,20 @@ def update_func(button_c):
                 else:
                     mountain_string = '.'
 
-
-                display(HTML('<p style="font-size:35px;font-weight:bold;"><br>' + station_name +  \
-                         ' station characterisation</p><p style="font-size:18px;"><br>'+ station_name + ' (' + station_code +\
-                             ') is a class ' + str(station_class) + ' ICOS atmospheric station of the type ' + station_site_type.lower() + \
-                             ' located in ' + station_country + ' (latitude: ' + str("%.2f" % station_lat) +\
-                             degree_sign + 'N, ' + 'longitude: ' + str("%.2f" % station_lon) +\
-                             degree_sign + 'E). The model height is ' + str(model_height)+ ' meters above ground' + mountain_string + '<br></p>'))
+                if station_site_type is not None:
+                    display(HTML('<p style="font-size:35px;font-weight:bold;"><br>' + station_name +  \
+                             ' station characterisation</p><p style="font-size:18px;"><br>'+ station_name + ' (' + station_code +\
+                                 ') is a class ' + str(station_class) + ' ICOS atmospheric station of the type ' + station_site_type.lower() + \
+                                 ' located in ' + station_country + ' (latitude: ' + str("%.2f" % station_lat) +\
+                                 degree_sign + 'N, ' + 'longitude: ' + str("%.2f" % station_lon) +\
+                                 degree_sign + 'E). The model height is ' + str(model_height)+ ' meters above ground' + mountain_string + '<br></p>'))
+                else:
+                    display(HTML('<p style="font-size:35px;font-weight:bold;"><br>' + station_name +  \
+                             ' station characterisation</p><p style="font-size:18px;"><br>'+ station_name + ' (' + station_code +\
+                                 ') is a class ' + str(station_class) + ' ICOS atmospheric station (undefined station type) ' + \
+                                 ' located in ' + station_country + ' (latitude: ' + str("%.2f" % station_lat) +\
+                                 degree_sign + 'N, ' + 'longitude: ' + str("%.2f" % station_lon) +\
+                                 degree_sign + 'E). The model height is ' + str(model_height)+ ' meters above ground' + mountain_string + '<br></p>'))
 
             else:
 

--- a/notebooks/icos_jupyter_notebooks/station_characterization/tex.py
+++ b/notebooks/icos_jupyter_notebooks/station_characterization/tex.py
@@ -357,8 +357,13 @@ def generate_pdf_tex(stc):
             
         tex=tex.replace('**lat**', str(round(stc.settings['icos']['lat'], 2)))
         tex=tex.replace('**lon**', str(round(stc.settings['icos']['lon'], 2)))
-        tex=tex.replace('**class_type_text**', ('a class ' + str(stc.settings['icos']['icosclass']) +\
-                       ' ICOS atmospheric station of the type ``\MakeLowercase{' + str(stc.settings['icos']['siteType']) + '}\'\''))
+        
+        if stc.settings['icos']['siteType'] is not None:
+            tex=tex.replace('**class_type_text**', ('a class ' + str(stc.settings['icos']['icosclass']) +\
+                           ' ICOS atmospheric station of the type ``\MakeLowercase{' + str(stc.settings['icos']['siteType']) + '}\'\''))
+        else:
+            tex=tex.replace('**class_type_text**', ('a class ' + str(stc.settings['icos']['icosclass']) +\
+                               ' ICOS atmospheric station (undefined station type)'))
 
     else:
         if '_' in stc.settings['stilt']['name']:


### PR DESCRIPTION
Not all ICOS stations ('icos' == False) have siteType (and icosclass). Currently:

'Bialystok 180m(BIK180)',
 'Bialystok 300m(BIK300)',
 'Beromünster 212m(BRM212)',
 'BRM213 212m(BRM213)',
 'CBW 207m(CBW)',
 'Cabauw 27m(CBW027)',
 'Cabauw 67m(CBW067)',
 'Cabauw 127m(CBW127)',
 'Cabauw 207m(CBW207)',
 'Finokalia 15m(FKL015)',
 'Heidelberg 30m(HEI)',
 'Hegyhátsál 96m(HUN096)',
 'Hegyhátsál 115m(HUN115)',
 'Kasprowy Wierch 480m(KAS)',
 'Mace Head 15m(MHD)',
 'Observatoire Haute Provence 100m(OHP100)',
 'Pic du Midi 800m(PDM)',
 'Roc Tredudon 140m(ROC140)',
 'Tacolneston 191m(TAC191)'

Previously the station characterization tool would fail to create the info text where this information is used. It also would fail when creating the PDF for the same reason. These changes allow for these to be None.


