### PR TITLE
Changed animation rc param for matplotlib 

### DIFF
--- a/notebooks/pylib_examples/ex6b_STILT_footprint_animation.ipynb
+++ b/notebooks/pylib_examples/ex6b_STILT_footprint_animation.ipynb
@@ -36,7 +36,8 @@
     "from icoscp.stilt import stiltstation\n",
     "import numpy as np\n",
     "from IPython.display import HTML, display\n",
-    "from matplotlib import pyplot as plt, animation\n",
+    "from matplotlib import pyplot as plt, animation, rcParams\n",
+    "\n",
     "# Display footprints in logarithmic scale\n",
     "from matplotlib.colors import LogNorm\n",
     "\n",
@@ -201,6 +202,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# In order to make the above animation we need to change the limit size for animations:\n",
+    "rcParams['animation.embed_limit'] = 2**22\n",
+    "\n",
     "HTML(ani.to_jshtml())"
    ]
   },


### PR DESCRIPTION
The memory limit for the animation of pylib example 6b was exceeded. 