### PR TITLE
updates to work on new release / images

### DIFF
--- a/notebooks/icos_jupyter_notebooks/network_characterization/gui_network_characterization.py
+++ b/notebooks/icos_jupyter_notebooks/network_characterization/gui_network_characterization.py
@@ -274,11 +274,17 @@ def file_set_widgets(c):
     uploaded_file = file_name.value
 
     #check if there is content in the dictionary (uploaded file)
-    if bool(uploaded_file):
-        
+    if type(uploaded_file) is tuple:
+            # unless tobytes() is used, settings_concent will be of type "memoryview"
+            settings_content = uploaded_file[0]['content'].tobytes()
+            settings_dict = json.loads(settings_content)
+            set_settings(settings_dict)
+
+    #this works on exploredata (uploaded_file = dictionary)
+    else:
         settings_file=uploaded_file[list(uploaded_file.keys())[0]]['content']
         settings_json = settings_file.decode('utf8').replace("'", '"')
-        settings_dict = json.loads(settings_json)
+        settings_dict = json.loads(settings_file.tobytes())
         set_settings(settings_dict)
 
 def change_yr(c):

--- a/notebooks/icos_jupyter_notebooks/network_characterization/gui_network_characterization.py
+++ b/notebooks/icos_jupyter_notebooks/network_characterization/gui_network_characterization.py
@@ -21,7 +21,6 @@ import ipywidgets as widgets
 from bokeh.io import show, output_notebook, reset_output
 import matplotlib.pyplot as plt
 
-
 # style to supress scrolling in the output 
 style_scroll = """
     <style>
@@ -273,22 +272,14 @@ def change_selected_countries(c):
 def file_set_widgets(c):
     
     uploaded_file = file_name.value
-    
+
     #check if there is content in the dictionary (uploaded file)
     if bool(uploaded_file):
         
-        if type(uploaded_file) is tuple:
-            # unless tobytes() is used, settings_concent will be of type "memoryview"
-            settings_content = uploaded_file[0]['content'].tobytes()
-            settings_dict = json.loads(settings_content)
-            set_settings(settings_dict)
-        
-        #this works on exploredata (uploaded_file = dictionary)
-        else:
-            settings_file=uploaded_file[list(uploaded_file.keys())[0]]['content']
-            settings_json = settings_file.decode('utf8').replace("'", '"')
-            settings_dict = json.loads(settings_file.tobytes())
-            set_settings(settings_dict)
+        settings_file=uploaded_file[list(uploaded_file.keys())[0]]['content']
+        settings_json = settings_file.decode('utf8').replace("'", '"')
+        settings_dict = json.loads(settings_json)
+        set_settings(settings_dict)
 
 def change_yr(c):
     
@@ -400,8 +391,7 @@ def clear_selection_compare(button_c):
 #----------- start processing -----------------
 
 def update_func(button_c):
-    
-    
+
     update_button.disabled = True
     clear_all_output()
     
@@ -638,7 +628,7 @@ selected_compare_network_stations.layout.margin = '0px 0px 0px 70px' #top, right
 
 
 #Create a Dropdown widget with year values (start year):
-s_year = Dropdown(options = range(2006, 2021),
+s_year = Dropdown(options = range(2006, 2022),
                   value = 2018,
                   description = 'Start Year',
                   disabled= False,
@@ -653,7 +643,7 @@ s_month = Dropdown(options = range(1, 13),
                   layout=layout)
 
 #Create a Dropdown widget with year values (end year):
-e_year = Dropdown(options = range(2018, 2021),
+e_year = Dropdown(options = range(2018, 2022),
                   value = 2018,
                   description = 'End Year',
                   disabled= False,

--- a/notebooks/icos_jupyter_notebooks/network_characterization/gui_percent_aggregate_footprints.py
+++ b/notebooks/icos_jupyter_notebooks/network_characterization/gui_percent_aggregate_footprints.py
@@ -40,7 +40,6 @@ list_2018_not_located = [(('In water' + ': ' + v['name'] + ' ('+ k + ')'),k) for
 list_2018 = list_2018_not_located + list_2018_located 
 
 def prepare_footprints_change(c):
-    station_choice.options = () 
 
     if prepared_footprints.value == False:
         
@@ -71,13 +70,6 @@ def prepare_footprints_change(c):
         e_day.disabled = True
 
         time_selection.disabled = True
-        
-# check if it is a valid date range, enable/disable update button in accordance.
-def check_date_range():
-    if s_year.value==e_year.value and s_month.value == e_month.value and e_day.value == s_day.value:
-        update_button.disabled = True
-    else:
-        update_button.disabled = False
 
 # observer functions
 def change_stn(c): 
@@ -101,7 +93,6 @@ def change_yr(c):
     e_year.options = years
     e_month.options = month
     e_month.value = min(month)
-    check_date_range()
 
 def change_mt(c):
     
@@ -128,8 +119,6 @@ def change_mt(c):
         day = [x for x in s_day.options if x >= s_day.value]
         e_day.options=day
         e_day.value = min(day)
-        
-    check_date_range()
 
 def change_yr_end(c):
     
@@ -163,8 +152,6 @@ def change_yr_end(c):
             
         e_day.value = 1
     
-    check_date_range()
-
 def change_day(c):
     
     #when change the day... if the same month and year (start) - update
@@ -177,8 +164,6 @@ def change_day(c):
             e_day.value = original_value
         else:
             e_day.value = min(allowed_days)
-    
-    check_date_range()
     
 def change_month_end(c):
     
@@ -199,12 +184,6 @@ def change_month_end(c):
         else:
             e_day.options=list(range(1,29))          
         e_day.value = 1
-    
-    check_date_range()
-    
-def change_day_end(c):
-    
-    check_date_range()
 
 def update_func(button_c):
 
@@ -336,7 +315,7 @@ colorbar_choice = Dropdown(
 
 #Create a Button widget to control execution:
 update_button = Button(description='Run selection',
-                       disabled=True,
+                       disabled=False,
                        button_style='danger', # 'success', 'info', 'warning', 'danger' or ''
                        tooltip='Click me',)
 
@@ -405,8 +384,7 @@ def observe():
     s_day.observe(change_day, 'value')
     e_year.observe(change_yr_end, 'value')
     e_month.observe(change_month_end, 'value')
-    e_day.observe(change_day_end, 'value')
-    
+
     update_button.on_click(update_func)
 
 def unobserve():    

--- a/notebooks/icos_jupyter_notebooks/network_characterization/gui_percent_aggregate_footprints.py
+++ b/notebooks/icos_jupyter_notebooks/network_characterization/gui_percent_aggregate_footprints.py
@@ -71,11 +71,17 @@ def prepare_footprints_change(c):
         e_day.disabled = True
 
         time_selection.disabled = True
+        
+# check if it is a valid date range, enable/disable update button in accordance.
+def check_date_range():
+    if s_year.value==e_year.value and s_month.value == e_month.value and e_day.value == s_day.value:
+        update_button.disabled = True
+    else:
+        update_button.disabled = False
 
+# observer functions
 def change_stn(c): 
  
-    update_button.disabled = False
-
     years = sorted(stiltstations[station_choice.value]['years'])    
     years = [int(x) for x in years] 
 
@@ -87,15 +93,15 @@ def change_stn(c):
 def change_yr(c):
     
     years = [x for x in s_year.options if x >= s_year.value]
-    e_year.options = years
-        
     #extract available months 
     month = sorted(stiltstations[station_choice.value][str(s_year.value)]['months'])
     month = [int(x) for x in month]
     s_month.options= month
     s_month.value = min(month)
+    e_year.options = years
     e_month.options = month
     e_month.value = min(month)
+    check_date_range()
 
 def change_mt(c):
     
@@ -122,6 +128,8 @@ def change_mt(c):
         day = [x for x in s_day.options if x >= s_day.value]
         e_day.options=day
         e_day.value = min(day)
+        
+    check_date_range()
 
 def change_yr_end(c):
     
@@ -154,6 +162,8 @@ def change_yr_end(c):
             e_day.options=list(range(1,29))
             
         e_day.value = 1
+    
+    check_date_range()
 
 def change_day(c):
     
@@ -167,6 +177,8 @@ def change_day(c):
             e_day.value = original_value
         else:
             e_day.value = min(allowed_days)
+    
+    check_date_range()
     
 def change_month_end(c):
     
@@ -187,7 +199,12 @@ def change_month_end(c):
         else:
             e_day.options=list(range(1,29))          
         e_day.value = 1
-            
+    
+    check_date_range()
+    
+def change_day_end(c):
+    
+    check_date_range()
 
 def update_func(button_c):
 
@@ -319,7 +336,7 @@ colorbar_choice = Dropdown(
 
 #Create a Button widget to control execution:
 update_button = Button(description='Run selection',
-                       #disabled=True,
+                       disabled=True,
                        button_style='danger', # 'success', 'info', 'warning', 'danger' or ''
                        tooltip='Click me',)
 
@@ -388,6 +405,7 @@ def observe():
     s_day.observe(change_day, 'value')
     e_year.observe(change_yr_end, 'value')
     e_month.observe(change_month_end, 'value')
+    e_day.observe(change_day_end, 'value')
     
     update_button.on_click(update_func)
 
@@ -398,6 +416,7 @@ def unobserve():
     s_day.unobserve(change_day, 'value')    
     e_year.unobserve(change_yr_end, 'value')
     e_month.unobserve(change_month_end, 'value')
+    e_day.unobserve(change_day_end, 'value')
     
 # start observation
 observe()

--- a/notebooks/icos_jupyter_notebooks/radiocarbon/gui_stilt.py
+++ b/notebooks/icos_jupyter_notebooks/radiocarbon/gui_stilt.py
@@ -292,13 +292,18 @@ def file_set_widgets(c):
     uploaded_file = file_name.value
     
     #check if there is content in the dictionary (uploaded file)
-    if bool(uploaded_file):
-        
+    if type(uploaded_file) is tuple:
+            # unless tobytes() is used, settings_concent will be of type "memoryview"
+            settings_content = uploaded_file[0]['content'].tobytes()
+            settings_dict = json.loads(settings_content)
+            set_settings(settings_dict)
+
+    #this works on exploredata (uploaded_file = dictionary)
+    else:
         settings_file=uploaded_file[list(uploaded_file.keys())[0]]['content']
         settings_json = settings_file.decode('utf8').replace("'", '"')
-        settings_dict = json.loads(settings_json)
+        settings_dict = json.loads(settings_file.tobytes())
         set_settings(settings_dict)
-
 #----------- start processing -----------------
 
 def updateProgress(f, desc=''):

--- a/notebooks/icos_jupyter_notebooks/radiocarbon/gui_stilt.py
+++ b/notebooks/icos_jupyter_notebooks/radiocarbon/gui_stilt.py
@@ -15,7 +15,6 @@ import matplotlib.pyplot as plt
 from datetime import datetime
 import json
 button_color_able='#4169E1'
-button_color_disable='#900D09'
 import warnings
 warnings.filterwarnings('ignore')
 
@@ -106,17 +105,20 @@ def set_settings(s):
         resample_str = s['resample']
         resample_int = int(resample_str[:-1])
         resample.value = resample_int
+
+# check if it is a valid date range, enable/disable update button in accordance.
+def check_date_range():
+    if s_year.value==e_year.value and s_month.value == e_month.value and e_day.value == s_day.value:
+        update_button.disabled = True
+    else:
+        update_button.disabled = False
         
 # observer functions
-
-#---------------------------------------------------------
-    
 def change_stn_type(c): 
     
     # disable update button until date and time defined (see how these are reset below)
     update_button.disabled = True
     update_button.tooltip = 'Unable to run'
-    update_button.style.button_color=button_color_disable
 
     # make sure the new 'options' are not selected..
     unobserve()    
@@ -156,17 +158,17 @@ def change_stn(c):
     
 
 def change_yr(c):
-    
+
     years = [x for x in s_year.options if x >= s_year.value]
-    e_year.options = years
-        
     #extract available months 
     month = sorted(stiltstations[station_choice.value][str(s_year.value)]['months'])
     month = [int(x) for x in month]
     s_month.options= month
     s_month.value = min(month)
+    e_year.options = years
     e_month.options = month
     e_month.value = min(month)
+    check_date_range()
 
 def change_mt(c):
     
@@ -193,11 +195,13 @@ def change_mt(c):
         day = [x for x in s_day.options if x >= s_day.value]
         e_day.options=day
         e_day.value = min(day)
+        
+    check_date_range()
 
 def change_yr_end(c):
     
     if s_year.value==e_year.value:
-        month = [x for x in s_month.options if x >= s_month.value]        
+        month = [x for x in s_month.options if x >= s_month.value]
         e_month.options = month
         e_month.value = min(month)
     else:
@@ -225,6 +229,8 @@ def change_yr_end(c):
             e_day.options=list(range(1,29))
             
         e_day.value = 1
+        
+    check_date_range()
 
 def change_day(c):
     
@@ -238,6 +244,8 @@ def change_day(c):
             e_day.value = original_value
         else:
             e_day.value = min(allowed_days)
+            
+    check_date_range()
     
 def change_month_end(c):
     
@@ -259,12 +267,11 @@ def change_month_end(c):
             e_day.options=list(range(1,29))          
         e_day.value = 1
     
+    check_date_range()
+    
 def change_day_end(c):
     
-    if s_year.value==e_year.value and s_month.value == e_month.value and e_day.value == s_day.value:
-        update_button.disabled = True
-    else:
-        update_button.disabled = False
+    check_date_range()
 
 def change_resample_monthly(c):
     
@@ -287,18 +294,10 @@ def file_set_widgets(c):
     #check if there is content in the dictionary (uploaded file)
     if bool(uploaded_file):
         
-        if type(uploaded_file) is tuple:
-            # unless tobytes() is used, settings_concent will be of type "memoryview"
-            settings_content = uploaded_file[0]['content'].tobytes()
-            settings_dict = json.loads(settings_content)
-            set_settings(settings_dict)
-        
-        #this works on exploredata (uploaded_file = dictionary)
-        else:
-            settings_file=uploaded_file[list(uploaded_file.keys())[0]]['content']
-            settings_json = settings_file.decode('utf8').replace("'", '"')
-            settings_dict = json.loads(settings_file.tobytes())
-            set_settings(settings_dict)
+        settings_file=uploaded_file[list(uploaded_file.keys())[0]]['content']
+        settings_json = settings_file.decode('utf8').replace("'", '"')
+        settings_dict = json.loads(settings_json)
+        set_settings(settings_dict)
 
 #----------- start processing -----------------
 

--- a/notebooks/icos_jupyter_notebooks/station_characterization/gui.py
+++ b/notebooks/icos_jupyter_notebooks/station_characterization/gui.py
@@ -270,13 +270,18 @@ def file_set_widgets(c):
     uploaded_file = file_name.value
     
     #check if there is content in the dictionary (uploaded file)
-    if bool(uploaded_file):
-        
+    if type(uploaded_file) is tuple:
+            # unless tobytes() is used, settings_concent will be of type "memoryview"
+            settings_content = uploaded_file[0]['content'].tobytes()
+            settings_dict = json.loads(settings_content)
+            set_settings(settings_dict)
+
+    #this works on exploredata (uploaded_file = dictionary)
+    else:
         settings_file=uploaded_file[list(uploaded_file.keys())[0]]['content']
         settings_json = settings_file.decode('utf8').replace("'", '"')
-        settings_dict = json.loads(settings_json)
+        settings_dict = json.loads(settings_file.tobytes())
         set_settings(settings_dict)
-    
 #----------- start processing -----------------
      
 def updateProgress(f, desc=''):

--- a/notebooks/icos_jupyter_notebooks/station_characterization/gui.py
+++ b/notebooks/icos_jupyter_notebooks/station_characterization/gui.py
@@ -101,6 +101,13 @@ def set_settings(s):
     except:
         fig_format.value = 'pdf'
 
+        
+# check if it is a valid date range, enable/disable update button in accordance.
+def check_date_range():
+    if s_year.value==e_year.value and s_month.value == e_month.value and e_day.value == s_day.value:
+        update_button.disabled = True
+    else:
+        update_button.disabled = False
 # observer functions: things that happen when specific widgets changes
 #---------------------------------------------------------
 def change_stn_type(c): 
@@ -149,15 +156,15 @@ def change_stn(c):
 def change_yr(c):
     
     years = [x for x in s_year.options if x >= s_year.value]
-    e_year.options = years
-        
     #extract available months 
     month = sorted(stiltstations[station_choice.value][str(s_year.value)]['months'])
     month = [int(x) for x in month]
     s_month.options= month
     s_month.value = min(month)
+    e_year.options = years
     e_month.options = month
     e_month.value = min(month)
+    check_date_range()
 
 def change_mt(c):
     
@@ -184,6 +191,8 @@ def change_mt(c):
         day = [x for x in s_day.options if x >= s_day.value]
         e_day.options=day
         e_day.value = min(day)
+        
+    check_date_range()
 
 def change_yr_end(c):
     
@@ -216,6 +225,7 @@ def change_yr_end(c):
             e_day.options=list(range(1,29))
             
         e_day.value = 1
+    check_date_range()
 
 def change_day(c):
     
@@ -228,7 +238,8 @@ def change_day(c):
         if original_value in allowed_days:
             e_day.value = original_value
         else:
-            e_day.value = min(allowed_days)
+            e_day.value = min(allowed_days)          
+    check_date_range()
     
 def change_month_end(c):
     
@@ -249,6 +260,10 @@ def change_month_end(c):
         else:
             e_day.options=list(range(1,29))          
         e_day.value = 1
+    check_date_range()
+    
+def change_day_end(c):
+    check_date_range()
         
 def file_set_widgets(c):
     
@@ -257,18 +272,10 @@ def file_set_widgets(c):
     #check if there is content in the dictionary (uploaded file)
     if bool(uploaded_file):
         
-        if type(uploaded_file) is tuple:
-            # unless tobytes() is used, settings_concent will be of type "memoryview"
-            settings_content = uploaded_file[0]['content'].tobytes()
-            settings_dict = json.loads(settings_content)
-            set_settings(settings_dict)
-        
-        #this works on exploredata (uploaded_file = dictionary)
-        else:
-            settings_file=uploaded_file[list(uploaded_file.keys())[0]]['content']
-            settings_json = settings_file.decode('utf8').replace("'", '"')
-            settings_dict = json.loads(settings_file.tobytes())
-            set_settings(settings_dict)
+        settings_file=uploaded_file[list(uploaded_file.keys())[0]]['content']
+        settings_json = settings_file.decode('utf8').replace("'", '"')
+        settings_dict = json.loads(settings_json)
+        set_settings(settings_dict)
     
 #----------- start processing -----------------
      
@@ -720,6 +727,7 @@ def observe():
     s_day.observe(change_day, 'value')
     e_year.observe(change_yr_end, 'value')
     e_month.observe(change_month_end, 'value')
+    e_day.observe(change_day_end, 'value')
     file_name.observe(file_set_widgets, 'value')
     
     #Call update-function when button is clicked:
@@ -733,6 +741,7 @@ def unobserve():
     s_day.unobserve(change_day, 'value')    
     e_year.unobserve(change_yr_end, 'value')
     e_month.unobserve(change_month_end, 'value')
+    e_day.unobserve(change_day_end, 'value')
     
 # start observation
 observe()

--- a/notebooks/project_jupyter_notebooks/envrifair_winterschool/timeseries/icos_obs_vs_stilt_timeseries.ipynb
+++ b/notebooks/project_jupyter_notebooks/envrifair_winterschool/timeseries/icos_obs_vs_stilt_timeseries.ipynb
@@ -85,9 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Import modules:\n",
@@ -159,9 +157,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Call method to get a data object containing\n",
@@ -182,9 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Get data for this object:\n",
@@ -215,9 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Filter observations using quality flag values:\n",
@@ -237,9 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#The metadata dictionary keys are:\n",
@@ -249,9 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#The PID to the data object\n",
@@ -261,9 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#The 'accessUrl' key gives a link where the data can be downloaded  \n",
@@ -273,9 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#The key 'coverageGeo' holds information on the geographical position of the station:\n",
@@ -285,9 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Under 'specificInfo' we have info about the station and about the data itself:\n",
@@ -297,9 +279,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# or we can use the property .variables\n",
@@ -328,9 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Plot CO2 time series:\n",
@@ -350,9 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Label for the data\n",
@@ -390,9 +366,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Change the size of the plot:\n",
@@ -414,9 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Add data citation to your plot:\n",
@@ -436,9 +408,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Call function to get plot object:\n",
@@ -468,9 +438,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#View summarized statistics for co2 observations:\n",
@@ -490,9 +458,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Set time as index:\n",
@@ -515,9 +481,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Calculate montly mean:\n",
@@ -540,9 +504,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Calculate standard deviation per month:\n",
@@ -564,9 +526,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Plot monthly means:\n",
@@ -600,9 +560,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Create STILT-object:\n",
@@ -620,9 +578,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "stilt_df = sobj.get_ts('2016-05-10','2020-05-31')\n",
@@ -642,9 +598,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "stilt_df['co2.stilt'].plot(title='STILT CO2 time series ('+station+')',\n",
@@ -672,9 +626,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ax = dobj.data.plot(x='TIMESTAMP', y='co2', figsize=(16,8),\n",
@@ -707,9 +659,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Select co2 observations in 3-hourly intervals:\n",
@@ -737,9 +687,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Calculate diff:\n",
@@ -760,9 +708,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Calculate diff_alternative:\n",
@@ -782,9 +728,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "diff_alternative.dropna(inplace=True)\n",
@@ -802,13 +746,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Filter by time:\n",
-    "#diff = diff.loc[datetime(2018,1,1):datetime(2019,1,1)]\n",
+    "#diff = diff.loc[pd.to_datetime('2018-1-1'):pd.to_datetime('2019-1-1')]\n",
     "\n",
     "#Show result:\n",
     "#diff"
@@ -828,9 +770,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Plot diff (static plot):\n",
@@ -849,9 +789,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Call function to get plot object:\n",
@@ -876,9 +814,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Get descriptive statistics over the difference:\n",
@@ -895,9 +831,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "co2_3h_df.corr(stilt_df['co2.stilt'], method='pearson')"
@@ -906,9 +840,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Attention! Make sure that you have performed the analysis over data from the same station:\n",
@@ -939,16 +871,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -962,7 +892,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.10.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/project_jupyter_notebooks/network-view-tool/network_view/network_analysis_functions.py
+++ b/notebooks/project_jupyter_notebooks/network-view-tool/network_view/network_analysis_functions.py
@@ -2159,143 +2159,143 @@ def land_cover_bar_graph_winter_summer(stc, output=output, pngfile='landcover_su
         degrees=degrees_from_point_to_grid_cells(station_lat, station_lon, load_lat, load_lon)
 
 
-    # take two date ranges for final graph
-    fp1 = read_aggreg_footprints(station, date_range1)
-    f.value += 1
-
-    fp2 = read_aggreg_footprints(station, date_range2)
-    f.value += 1
-
     #get all the land cover data from netcdfs 
     broad_leaf_forest, coniferous_forest, mixed_forest, ocean, other, grass_shrub, cropland, pasture, urban, unknown = import_landcover_HILDA(year='2018')
+    
+    fp = read_aggreg_footprints(station, date_range1)
+    
+    f.value += 1
 
-    #land cover classes (imported in the land cover section):
-    broad_leaf_forest1=fp1*broad_leaf_forest
-    coniferous_forest1=fp1*coniferous_forest
-    mixed_forest1=fp1*mixed_forest
-    ocean1=fp1*ocean
-    other1=fp1*other
-    grass_shrub1=fp1*grass_shrub
-    cropland1=fp1*cropland
-    pasture1=fp1*pasture
-    urban1=fp1*urban
-    unknown1=fp1*unknown
-
-    broad_leaf_forest2=fp2*broad_leaf_forest
-    coniferous_forest2=fp2*coniferous_forest
-    mixed_forest2=fp2*mixed_forest
-    ocean2=fp2*ocean
-    other2=fp2*other
-    grass_shrub2=fp2*grass_shrub
-    cropland2=fp2*cropland
-    pasture2=fp2*pasture
-    urban2=fp2*urban
-    unknown2=fp2*unknown
+    broad_leaf_forest_fp=fp*broad_leaf_forest
+    coniferous_forest_fp=fp*coniferous_forest
+    mixed_forest_fp=fp*mixed_forest
+    ocean_fp=fp*ocean
+    other_fp=fp*other
+    grass_shrub_fp=fp*grass_shrub
+    cropland_fp=fp*cropland
+    pasture_fp=fp*pasture
+    urban_fp=fp*urban
+    unknown_fp=fp*unknown
 
     #lists of these values
-    broad_leaf_forest_values1 = [item for sublist in broad_leaf_forest1[0] for item in sublist]
-    coniferous_forest_values1 = [item for sublist in coniferous_forest1[0] for item in sublist]
-    mixed_forest_values1 = [item for sublist in mixed_forest1[0] for item in sublist]
-    ocean_values1 = [item for sublist in ocean1[0] for item in sublist]
-    other_values1 = [item for sublist in other1[0] for item in sublist]
-    grass_shrub_values1 = [item for sublist in grass_shrub1[0] for item in sublist]
-    cropland_values1 = [item for sublist in cropland1[0] for item in sublist]
-    pasture_values1 = [item for sublist in pasture1[0] for item in sublist]
-    urban_values1 = [item for sublist in urban1[0] for item in sublist]
-    unknown_values1 = [item for sublist in unknown1[0] for item in sublist]
-
-    broad_leaf_forest_values2 = [item for sublist in broad_leaf_forest2[0] for item in sublist]
-    coniferous_forest_values2 = [item for sublist in coniferous_forest2[0] for item in sublist]
-    mixed_forest_values2 = [item for sublist in mixed_forest2[0] for item in sublist]
-    ocean_values2 = [item for sublist in ocean2[0] for item in sublist]
-    other_values2 = [item for sublist in other2[0] for item in sublist]
-    grass_shrub_values2 = [item for sublist in grass_shrub2[0] for item in sublist]
-    cropland_values2 = [item for sublist in cropland2[0] for item in sublist]
-    pasture_values2 = [item for sublist in pasture2[0] for item in sublist]
-    urban_values2 = [item for sublist in urban2[0] for item in sublist]
-    unknown_values2 = [item for sublist in unknown2[0] for item in sublist]
-
-
+    broad_leaf_forest_values = [item for sublist in broad_leaf_forest_fp[0] for item in sublist]
+    coniferous_forest_values = [item for sublist in coniferous_forest_fp[0] for item in sublist]
+    mixed_forest_values = [item for sublist in mixed_forest_fp[0] for item in sublist]
+    ocean_values = [item for sublist in ocean_fp[0] for item in sublist]
+    other_values = [item for sublist in other_fp[0] for item in sublist]
+    grass_shrub_values = [item for sublist in grass_shrub_fp[0] for item in sublist]
+    cropland_values = [item for sublist in cropland_fp[0] for item in sublist]
+    pasture_values = [item for sublist in pasture_fp[0] for item in sublist]
+    urban_values = [item for sublist in urban_fp[0] for item in sublist]
+    unknown_values = [item for sublist in unknown_fp[0] for item in sublist]
+    
     #putting it into a dataframe: initially 192000 values (one per cell) for each of the aggregated land cover classes
     #into same dataframe - have the same coulmn heading. "landcover_type" will be used in "groupby" together with the "slice" (in degrees)
-    df_broad_leaf_forest1 = pd.DataFrame({'landcover_vals': broad_leaf_forest_values1,
+    df_broad_leaf_forest1 = pd.DataFrame({'landcover_vals': broad_leaf_forest_values,
                                'degrees': degrees,
                                'landcover_type':'Broad leaf forest'})
 
-    df_coniferous_forest1 = pd.DataFrame({'landcover_vals': coniferous_forest_values1,
+    df_coniferous_forest1 = pd.DataFrame({'landcover_vals': coniferous_forest_values,
                            'degrees': degrees,
                            'landcover_type':'Coniferous forest'})
 
-    df_mixed_forest1 = pd.DataFrame({'landcover_vals': mixed_forest_values1,
+    df_mixed_forest1 = pd.DataFrame({'landcover_vals': mixed_forest_values,
                            'degrees': degrees,
                            'landcover_type':'Mixed forest'})
 
-    df_ocean1 = pd.DataFrame({'landcover_vals': ocean_values1,
+    df_ocean1 = pd.DataFrame({'landcover_vals': ocean_values,
                            'degrees': degrees,
                            'landcover_type':'Ocean'})
 
-    df_other1 = pd.DataFrame({'landcover_vals': other_values1,
+    df_other1 = pd.DataFrame({'landcover_vals': other_values,
                            'degrees': degrees,
                            'landcover_type':'Other'})
 
-    df_grass_shrub1 = pd.DataFrame({'landcover_vals':  grass_shrub_values1,
+    df_grass_shrub1 = pd.DataFrame({'landcover_vals':  grass_shrub_values,
                            'degrees': degrees,
                            'landcover_type':'Grass/shrubland'})
 
-    df_cropland1 = pd.DataFrame({'landcover_vals':  cropland_values1,
+    df_cropland1 = pd.DataFrame({'landcover_vals':  cropland_values,
                            'degrees': degrees,
                            'landcover_type':'Cropland'})
 
-    df_pasture1 = pd.DataFrame({'landcover_vals': pasture_values1,
+    df_pasture1 = pd.DataFrame({'landcover_vals': pasture_values,
                            'degrees': degrees,
                            'landcover_type':'Pasture'})
 
-    df_urban1 = pd.DataFrame({'landcover_vals':  urban_values1,
+    df_urban1 = pd.DataFrame({'landcover_vals':  urban_values,
                            'degrees': degrees,
                            'landcover_type':'Urban'})
 
-    df_unknown1 = pd.DataFrame({'landcover_vals':  unknown_values1,
+    df_unknown1 = pd.DataFrame({'landcover_vals':  unknown_values,
                            'degrees': degrees,
                            'landcover_type':'Unknown'})
 
+    
+    fp = read_aggreg_footprints(station, date_range2)
+    f.value += 1
 
-    df_broad_leaf_forest2 = pd.DataFrame({'landcover_vals': broad_leaf_forest_values2,
+    broad_leaf_forest_fp=fp*broad_leaf_forest
+    coniferous_forest_fp=fp*coniferous_forest
+    mixed_forest_fp=fp*mixed_forest
+    ocean_fp=fp*ocean
+    other_fp=fp*other
+    grass_shrub_fp=fp*grass_shrub
+    cropland_fp=fp*cropland
+    pasture_fp=fp*pasture
+    urban_fp=fp*urban
+    unknown_fp=fp*unknown
+
+    #lists of these values
+    broad_leaf_forest_values = [item for sublist in broad_leaf_forest_fp[0] for item in sublist]
+    coniferous_forest_values = [item for sublist in coniferous_forest_fp[0] for item in sublist]
+    mixed_forest_values = [item for sublist in mixed_forest_fp[0] for item in sublist]
+    ocean_values = [item for sublist in ocean_fp[0] for item in sublist]
+    other_values = [item for sublist in other_fp[0] for item in sublist]
+    grass_shrub_values = [item for sublist in grass_shrub_fp[0] for item in sublist]
+    cropland_values = [item for sublist in cropland_fp[0] for item in sublist]
+    pasture_values = [item for sublist in pasture_fp[0] for item in sublist]
+    urban_values = [item for sublist in urban_fp[0] for item in sublist]
+    unknown_values = [item for sublist in unknown_fp[0] for item in sublist]
+    
+
+    df_broad_leaf_forest2 = pd.DataFrame({'landcover_vals': broad_leaf_forest_values,
                                'degrees': degrees,
                                'landcover_type':'Broad leaf forest'})
 
-    df_coniferous_forest2 = pd.DataFrame({'landcover_vals': coniferous_forest_values2,
+    df_coniferous_forest2 = pd.DataFrame({'landcover_vals': coniferous_forest_values,
                            'degrees': degrees,
                            'landcover_type':'Coniferous forest'})
 
-    df_mixed_forest2 = pd.DataFrame({'landcover_vals': mixed_forest_values2,
+    df_mixed_forest2 = pd.DataFrame({'landcover_vals': mixed_forest_values,
                            'degrees': degrees,
                            'landcover_type':'Mixed forest'})
 
-    df_ocean2 = pd.DataFrame({'landcover_vals': ocean_values2,
+    df_ocean2 = pd.DataFrame({'landcover_vals': ocean_values,
                            'degrees': degrees,
                            'landcover_type':'Ocean'})
 
-    df_other2 = pd.DataFrame({'landcover_vals': other_values2,
+    df_other2 = pd.DataFrame({'landcover_vals': other_values,
                            'degrees': degrees,
                            'landcover_type':'Other'})
 
-    df_grass_shrub2 = pd.DataFrame({'landcover_vals':  grass_shrub_values2,
+    df_grass_shrub2 = pd.DataFrame({'landcover_vals':  grass_shrub_values,
                            'degrees': degrees,
                            'landcover_type':'Grass/shrubland'})
 
-    df_cropland2 = pd.DataFrame({'landcover_vals':  cropland_values2,
+    df_cropland2 = pd.DataFrame({'landcover_vals':  cropland_values,
                            'degrees': degrees,
                            'landcover_type':'Cropland'})
 
-    df_pasture2 = pd.DataFrame({'landcover_vals': pasture_values2,
+    df_pasture2 = pd.DataFrame({'landcover_vals': pasture_values,
                            'degrees': degrees,
                            'landcover_type':'Pasture'})
 
-    df_urban2 = pd.DataFrame({'landcover_vals':  urban_values2,
+    df_urban2 = pd.DataFrame({'landcover_vals':  urban_values,
                            'degrees': degrees,
                            'landcover_type':'Urban'})
 
-    df_unknown2 = pd.DataFrame({'landcover_vals':  unknown_values2,
+    df_unknown2 = pd.DataFrame({'landcover_vals':  unknown_values,
                            'degrees': degrees,
                            'landcover_type':'Unknown'})
 

--- a/notebooks/project_jupyter_notebooks/network-view-tool/network_view/network_analysis_functions.py
+++ b/notebooks/project_jupyter_notebooks/network-view-tool/network_view/network_analysis_functions.py
@@ -6,7 +6,6 @@ from IPython.core.display import display, HTML
 from ipywidgets import Dropdown, Button, Output, SelectMultiple,GridspecLayout
 import numpy as np
 import json
-from numpy import loadtxt
 import pandas as pd
 import netCDF4 as cdf
 from netCDF4 import Dataset, date2index
@@ -18,10 +17,12 @@ from icoscp.sparql.runsparql import RunSparql
 from matplotlib.colors import LogNorm
 import matplotlib
 import matplotlib.pyplot as plt
+import cartopy.crs as ccrs
+import matplotlib.ticker as mticker
+from cartopy.mpl.gridliner import LONGITUDE_FORMATTER, LATITUDE_FORMATTER
 from cartopy.io.shapereader import Reader
 import cartopy
 import cartopy.feature as cfeature
-import cartopy.crs as ccrs
 import cartopy.io.shapereader as shpreader
 from cartopy.feature import ShapelyFeature
 cartopy.config['data_dir'] = '/data/project/cartopy/'
@@ -39,13 +40,11 @@ from matplotlib.legend import Legend
 import textwrap
 import statistics
 import warnings
-
 pathFP='/data/stiltweb/stations/'
 stcDataPath = '/data/project/stc/'
 path_cp = '/data/dataAppStorage/netcdf/'
-data_folder = '/data/project/stc/footprints_2018_averaged'
-load_lat=loadtxt(os.path.join(data_folder, 'latitude.csv'), delimiter=',')
-load_lon=loadtxt(os.path.join(data_folder, 'longitude.csv'), delimiter=',')
+load_lat = np.arange(33+((1/12)/2), 73, 1/12)
+load_lon = np.arange(-15 + ((1/8)/2), 35, 1/8)
 output = 'network_view/temp_output'
 
 country_masks = Dataset(os.path.join(stcDataPath,'europe_STILT_masks.nc'))
@@ -118,7 +117,7 @@ emission_for_cmap[:, 2] = np.linspace(106/256, 1, N)  # B
 emission_for_cmap_r = np.flip(emission_for_cmap, 0)
 emission_cmp = ListedColormap(emission_for_cmap_r)
 
-color_name_dict = {'gee':{'color':copy.copy(matplotlib.cm.get_cmap("Greens")), 'name' : 'GEE'}, 'resp':{'color':copy.copy(matplotlib.cm.get_cmap("Reds")), 'name' : 'Respiration'},
+color_name_dict = {'gee':{'color':copy.copy(matplotlib.cm.get_cmap("Greens")), 'name' : 'Total'}, 'resp':{'color':copy.copy(matplotlib.cm.get_cmap("Reds")), 'name' : 'Total'},
                    'broad_leaf_forest':{'color':blf_cmp, 'name' : 'Broad leaf forest'}, 'coniferous_forest':{'color':cf_cmp, 'name' : 'Coniferous forest'},\
         'grass_shrub':{'color':gs_cmp, 'name' : 'Grass and shrubland'}, 'mixed_forest':{'color':mf_cmp, 'name' : 'Mixed forest'},\
         'pasture':{'color':pasture_cmp, 'name' : 'Pasture'}, 'cropland':{'color':cropland_cmap, 'name' : 'Cropland'}, 'urban':{'color':copy.copy(matplotlib.cm.get_cmap("Reds")),'name' : 'Urban'}}
@@ -452,7 +451,13 @@ def plot_maps(field, lon, lat, nwc, footprint_stations='', title='', label='', u
         cbar = plt.colorbar(cs, orientation='horizontal',pad=0.03,fraction=0.055,extend=extend)
 
     cbar.set_label(label)
-     
+    
+    # grid lines:
+    gl = ax.gridlines(crs=ccrs.PlateCarree(), draw_labels=True,
+                  linewidth=0.5, color='gray', alpha=0.5)
+    gl.xformatter, gl.yformatter  = LONGITUDE_FORMATTER, LATITUDE_FORMATTER
+    gl.xlabel_style, gl.ylabel_style = {'size': 10, 'color': 'gray', 'alpha':0.5}, {'size': 10, 'color': 'gray', 'alpha':0.5}
+
     plt.title(title)
     
     if extended:
@@ -468,7 +473,7 @@ def plot_maps(field, lon, lat, nwc, footprint_stations='', title='', label='', u
         if not os.path.exists(output):
             os.makedirs(output)
   
-        fig.savefig(output+'/'+pngfile+'.png',dpi=100,bbox_inches='tight')
+        fig.savefig(output+'/'+pngfile+'.png',dpi=300,bbox_inches='tight')
         
         return plt
     
@@ -553,6 +558,12 @@ def plot_maps_country_zoom(field, lon, lat, nwc, country_code, output='monitorin
         cbar = plt.colorbar(cs, orientation='horizontal',pad=0.03,fraction=0.055,extend='both')
 
     cbar.set_label(label)
+    
+    # grid lines:
+    gl = ax.gridlines(crs=ccrs.PlateCarree(), draw_labels=True,
+                  linewidth=0.5, color='gray', alpha=0.5)
+    gl.xformatter, gl.yformatter  = LONGITUDE_FORMATTER, LATITUDE_FORMATTER
+    gl.xlabel_style, gl.ylabel_style = {'size': 10, 'color': 'gray', 'alpha':0.5}, {'size': 10, 'color': 'gray', 'alpha':0.5}
 
     plt.title(title)
     
@@ -571,7 +582,7 @@ def plot_maps_country_zoom(field, lon, lat, nwc, country_code, output='monitorin
         if not os.path.exists(output):
             os.makedirs(output)
   
-        fig.savefig(output+'/'+pngfile+'.png',dpi=100,bbox_inches='tight')
+        fig.savefig(output+'/'+pngfile+'.png',dpi=300,bbox_inches='tight')
     
     plt.close()
         
@@ -623,6 +634,12 @@ def plot_maps_two(field, field2, lon, lat, footprint_stations='', title='', labe
     ax.plot([-9.111, -59.111], [-9.112, -59.112], '-', label='Extended network', linewidth=8, color='#2171b5')
     
     ax.legend(loc='upper left', fontsize='medium')
+    
+    # grid lines:
+    gl = ax.gridlines(crs=ccrs.PlateCarree(), draw_labels=True,
+                  linewidth=0.5, color='gray', alpha=0.5)
+    gl.xformatter, gl.yformatter  = LONGITUDE_FORMATTER, LATITUDE_FORMATTER
+    gl.xlabel_style, gl.ylabel_style = {'size': 10, 'color': 'gray', 'alpha':0.5}, {'size': 10, 'color': 'gray', 'alpha':0.5}
 
     plt.title(title)
  
@@ -635,7 +652,7 @@ def plot_maps_two(field, field2, lon, lat, footprint_stations='', title='', labe
         if not os.path.exists(output):
             os.makedirs(output)
   
-        fig.savefig(output+'/'+pngfile+'.png',dpi=100,bbox_inches='tight')
+        fig.savefig(output+'/'+pngfile+'.png',dpi=300,bbox_inches='tight')
         
         return plt
     
@@ -990,7 +1007,7 @@ def landcover_view(nwc, countries, pngfile = '', output= ''):
     for country_code in sorted_country_list:
         if country_code == 'GBR':
             country_name = 'UK\n'
-        if country_code == 'SRB':
+        elif country_code == 'SRB':
             country_name = 'Serbia'
         else:
             country_name = dictionary_area_choice[country_code]
@@ -1020,12 +1037,13 @@ def landcover_view(nwc, countries, pngfile = '', output= ''):
         if not os.path.exists(output):
             os.makedirs(output)
   
-        plt.savefig(output+'/'+pngfile,dpi=100,bbox_inches='tight')
+        plt.savefig(output+'/'+pngfile,dpi=300,bbox_inches='tight')
     
     plt.show()
     
 def share_representaiton_table(nwc, countries, csvfile = '', output = ''):
 
+    selected_component = nwc['component']
     countries = list(countries)
     countries.insert(0, 'Europe')
     representation_file = nwc['networkFile'] + '_representation.csv'
@@ -1039,8 +1057,9 @@ def share_representaiton_table(nwc, countries, csvfile = '', output = ''):
     # usually the df_to_analyze contains a longer date range than the one of interest. 
     df_to_analyze_subset = df_to_analyze.loc[df_to_analyze['date'].isin(date_range_string_alt)]
     
-    columns =  ['Country', 'Broad leaf forest', 'Coniferous forest', 'Mixed forest', 'Other', 'Grass and shrubland', 'Cropland', \
-              'Pastures', 'Urban']
+    columns =  ['Country', 'Broad leaf forest (' + selected_component.upper() +')', 'Coniferous forest (' + selected_component.upper()+')', \
+                'Mixed forest (' + selected_component.upper()+')', 'Other (' + selected_component.upper()+')', 'Grass and shrubland (' + selected_component.upper()+')', 'Cropland (' + selected_component.upper()+')', \
+              'Pastures (' + selected_component.upper()+')', 'Urban (' + selected_component.upper()+')']
     
     df_country_flux_representation = pd.DataFrame(columns = columns)
 
@@ -1050,7 +1069,7 @@ def share_representaiton_table(nwc, countries, csvfile = '', output = ''):
 
         for column in df_to_analyze_subset.columns:
 
-            if country in column and 'gee' in column:
+            if country in column and selected_component.lower() in column:
                 
                 if 'broad_leaf_forest' in column or 'coniferous_forest' in column or 'mixed_forest' in column \
                 or 'cropland' in column or 'pasture' in column or 'urban' in column or 'grass_shrub' in column or 'other' in column:
@@ -1081,12 +1100,15 @@ def share_representaiton_table(nwc, countries, csvfile = '', output = ''):
     
 def flux_breakdown_countries_percentages(nwc, countries, pngfile='', output=''):
     
+    selected_component = nwc['component'] 
+    
     representation_file = nwc['networkFile'] + '_representation.csv'
     
     df_fluxes_full = pd.read_csv(os.path.join(nwc['pathFp'] + '_representation', representation_file))
         
     date_range = pd.date_range(dt.datetime(nwc['startYear'],nwc['startMonth'],nwc['startDay'],0), (dt.datetime(nwc['endYear'], nwc['endMonth'], nwc['endDay'], 21)), freq='3H')
     date_range_subset = [date for date in date_range if date.hour in nwc['timeOfDay']]
+
     date_range_string_alt = [str(date.year) + '-' + str(date.month) + '-' + str(date.day) + ' ' + str(date.hour) for date in date_range_subset]
 
     # usually the df_fluxes_full contains a longer date range than the one of interest. 
@@ -1149,8 +1171,8 @@ def flux_breakdown_countries_percentages(nwc, countries, pngfile='', output=''):
 
         for column in df_fluxes.columns:
             if country in column:
-                if 'gee' in column:
-
+                #if 'gee' in column:
+                if selected_component.lower() in column:
                     if 'total' not in column:
 
                         # added
@@ -1170,16 +1192,6 @@ def flux_breakdown_countries_percentages(nwc, countries, pngfile='', output=''):
 
         df_even_mean = df_even.mean()
         
-        # see if all are the same (zero):
-        df_even_mean_test_unique = df_even_mean.to_numpy() 
-        
-        # if all zero: return without table
-        if (df_even_mean_test_unique[0] == df_even_mean_test_unique).all():
-            
-            plt.close()
-            display(HTML('<p style="font-size:15px;"><mark>No GEE during the selected time-period</mark> (probably night-time selected). No GEE-based output created.</p>'))
-            return False
-
         df_even_mean_percent = (df_even_mean/df_even_mean.sum())*100
 
         df_network_mean = df_network.mean()
@@ -1194,10 +1206,10 @@ def flux_breakdown_countries_percentages(nwc, countries, pngfile='', output=''):
         for landcover, landcover_color in zip(land_cover_types, colors): 
             
             # now percent
-            value = float(df_network_mean_percent[country + '_' + landcover + '_gee'])
+            value = float(df_network_mean_percent[country + '_' + landcover + '_' + selected_component.lower()])
             
             # compare to percent country for every country (not just Europe)
-            value_country = float(df_even_mean_percent[country + '_' + landcover + '_gee_even'])
+            value_country = float(df_even_mean_percent[country + '_' + landcover + '_' + selected_component.lower() +'_even'])
 
             if first and landcover == 'broad_leaf_forest':
                     
@@ -1285,7 +1297,7 @@ def flux_breakdown_countries_percentages(nwc, countries, pngfile='', output=''):
     plt.axvline(x=y_pos_minus-(y_pos_steps*1.5), color = 'black', ls= '--')
     ax.set_ylabel('%')
               
-    fig.text(.5, 1, "GEE sensed by the network within country (left) vs. present in country (right)", ha='center')
+    fig.text(.5, 1, selected_component.upper()+ " sensed by the network within country (left) vs. present in country (right)", ha='center')
     fig.text(0.5, 0, "Country (sensitivity/km²)", ha='center')
     
     plt.tight_layout()
@@ -1294,11 +1306,11 @@ def flux_breakdown_countries_percentages(nwc, countries, pngfile='', output=''):
         if not os.path.exists(output):
             os.makedirs(output)
   
-        plt.savefig(output+'/'+pngfile,dpi=100,bbox_inches='tight')
+        plt.savefig(output+'/'+pngfile,dpi=300,bbox_inches='tight')
 
     plt.show()
 
-    display(HTML('<p style="font-size:15px;"><b>Figures 5a, 7a, and 8b: Land cover share of flux (GEE) within the network footprint compared to the land cover share of flux (GEE) within the network for selected countries.</b></p>'))
+    display(HTML('<p style="font-size:15px;"><b>Figures 5a, 8a: Land cover share of flux (' + nwc['component'].upper() + ') within the network footprint compared to the land cover share of flux (' + nwc['component'].upper() + ') within the network for selected countries.</b></p>'))
 
     return True
     
@@ -1347,6 +1359,7 @@ def initiate_monitoring_potential_maps(nwc, extended = False):
 
 def monitoring_potential_maps(nwc, country, extended = False):
 
+    selected_component = nwc['component']
     folder = nwc['networkFile']
     path = nwc['pathFp']
 
@@ -1446,13 +1459,13 @@ def monitoring_potential_maps(nwc, country, extended = False):
         if first_vprm or date.year!=current_year:
 
             current_year = date.year
-            filename_resp = check_cp(path_cp,'VPRM_ECMWF_RESP_' + str(current_year) + '_CP.nc')
-            f_resp = cdf.Dataset(filename_resp)
-            filename_gee = check_cp(path_cp,'VPRM_ECMWF_GEE_' + str(current_year) + '_CP.nc')
-            f_gee = cdf.Dataset(filename_gee)
+            filename_component = check_cp(path_cp,'VPRM_ECMWF_' + selected_component.upper() + '_' + str(current_year) + '_CP.nc')
+            f_component = cdf.Dataset(filename_component)
+            #filename_gee = check_cp(path_cp,'VPRM_ECMWF_GEE_' + str(current_year) + '_CP.nc')
+            #f_gee = cdf.Dataset(filename_gee)
 
             # same for both datasets (GEE and resp)
-            times = f_gee.variables['time']
+            times = f_component.variables['time']
            
             first_vprm = False
         
@@ -1472,8 +1485,7 @@ def monitoring_potential_maps(nwc, country, extended = False):
         ntime = date2index(date,times,select='nearest')
         
         # GEE and respiration map for specific date/time
-        resp = f_resp.variables['RESP'][ntime][:][:]
-        gee = f_gee.variables['GEE'][ntime][:][:]
+        component = f_component.variables[selected_component.upper()][ntime][:][:]
 
         if extended:
             fp_network = footprints_extended.sel(time=date).network_foot.data
@@ -1488,13 +1500,13 @@ def monitoring_potential_maps(nwc, country, extended = False):
             sens_per_cell_list_for_extended_representation = [average_sens_for_extended_representation]*192000
             fp_network_even_for_extended_representation=np.array(sens_per_cell_list_for_extended_representation).reshape(480, 400)
             
-            fp_network_even_gee_average_extended = fp_network_even_for_extended_representation * gee * country_mask
+            fp_network_even_component_average_extended = fp_network_even_for_extended_representation * component * country_mask
             if first_average_for_extended_representation:
-                fp_network_even_gee_average_extended_for_average = fp_network_even_gee_average_extended
+                fp_network_even_component_average_extended_for_average = fp_network_even_component_average_extended
                 first_average_for_extended_representation = False
             else:
                 
-                fp_network_even_gee_average_extended_for_average = fp_network_even_gee_average_extended_for_average + fp_network_even_gee_average_extended
+                fp_network_even_component_average_extended_for_average = fp_network_even_component_average_extended_for_average + fp_network_even_component_average_extended
 
         else:
             fp_network = footprints.sel(time=date).network_foot.data
@@ -1507,46 +1519,37 @@ def monitoring_potential_maps(nwc, country, extended = False):
         fp_network_even=np.array(sens_per_cell_list).reshape(480, 400)
 
         # network view of fluxes
-        fp_network_resp = fp_network * resp * country_mask
-        fp_network_gee = fp_network * gee * country_mask
+        fp_network_component = fp_network * component * country_mask
 
         # equal view of fluxes
-        fp_network_even_resp = fp_network_even * resp * country_mask 
-        fp_network_even_gee = fp_network_even * gee * country_mask 
+        fp_network_even_component = fp_network_even * component * country_mask 
         
         # want the average for the selected date range
         if first_average:
-            
-            fp_network_resp_for_average = fp_network_resp
-            fp_network_gee_for_average = fp_network_gee
+
+            fp_network_component_for_average = fp_network_component
 
             # equal view of fluxes
-            fp_network_even_resp_for_average = fp_network_even_resp
-            fp_network_even_gee_for_average = fp_network_even_gee
+            fp_network_even_component_for_average = fp_network_even_component
             
             first_average = False
             
         else:    
-            
-            fp_network_resp_for_average = fp_network_resp_for_average + fp_network_resp
-            fp_network_gee_for_average = fp_network_gee_for_average + fp_network_gee
+            fp_network_component_for_average = fp_network_component_for_average + fp_network_component
 
             # equal view of fluxes
-            fp_network_even_resp_for_average = fp_network_even_resp_for_average + fp_network_even_resp
-            fp_network_even_gee_for_average = fp_network_even_gee_for_average + fp_network_even_gee
+            fp_network_even_component_for_average = fp_network_even_component_for_average + fp_network_even_component
         
         i = i + 1
     
-    fp_network_resp_average = fp_network_resp_for_average / i
-    fp_network_gee_average = fp_network_gee_for_average / i
+    fp_network_component_average = fp_network_component_for_average / i
 
     # equal view of fluxes
-    fp_network_even_resp_average = fp_network_even_resp_for_average / i
-    fp_network_even_gee_average = fp_network_even_gee_for_average / i
+    fp_network_even_component_average = fp_network_even_component_for_average / i
     
     if extended:
-        
-        fp_network_even_gee_average_extended = fp_network_even_gee_average_extended_for_average / i
+
+        fp_network_even_component_average_extended = fp_network_even_component_average_extended_for_average / i
 
     if country != 'Europe':
         
@@ -1559,22 +1562,22 @@ def monitoring_potential_maps(nwc, country, extended = False):
         colors = color_name_dict[landcover_name]['color']
         name = color_name_dict[landcover_name]['name']
 
-        footprint = fp_network_gee_average * landcover_fractions
-        footprint_even = fp_network_even_gee_average * landcover_fractions
+        footprint = fp_network_component_average * landcover_fractions
+        footprint_even = fp_network_even_component_average * landcover_fractions
 
         if footprint.sum() == 0:
             country_name = dictionary_area_choice[country]
             display(HTML('<p style="font-size:15px">Sensing of ' +  name +' in ' + country_name + ' is zero which means no monitoring potential maps can be created.</p>'))
             
             # if GEE is zero, it means the monitoring potential will be zero for all classes and we break out of the function. Otherwise, just break out of the loop.
-            if name == 'GEE':
+            if name == 'GEE' or name == 'Respiration':
                 return
             else:
                 continue
         
         # will not work for extended network - need to havethe even extended file also (for the representation value, only compare with the equal view of reference network to see the change
         if extended:
-            percent = (footprint.sum() / (fp_network_even_gee_average_extended* landcover_fractions).sum()) * 100
+            percent = (footprint.sum() / (fp_network_even_component_average_extended* landcover_fractions).sum()) * 100
             percent_compare = percent - 100 
         
         else:
@@ -1582,16 +1585,16 @@ def monitoring_potential_maps(nwc, country, extended = False):
             percent_compare = percent - 100 
 
         if percent_compare > 0:
-            add_for_title = '(+' + str("%.1f" % percent_compare) + '% representation)' 
+            add_for_title = '+' + str("%.1f" % percent_compare) + '% representation' 
 
         else:
-            add_for_title =  '(-' + str("%.1f" % abs(percent_compare)) + '% representation)'   
+            add_for_title =  '-' + str("%.1f" % abs(percent_compare)) + '% representation'   
 
         if country == 'Europe':
 
             name_underscore = name.replace(' ', '_')
             pngfile = name_underscore + '_monitoring_potential_Europe'
-            plot_maps(abs(footprint_even)-abs(footprint), load_lon, load_lat,nwc, title = (name + ' monitoring potential '+ add_for_title), colors = colors, label = 'relatively low potential                                                                           relatively high potential', monitoring_potential = True,  output=output, pngfile = pngfile, extend = 'max', extended = extended)
+            plot_maps(abs(footprint_even)-abs(footprint), load_lon, load_lat,nwc, title = (name + ' monitoring potential (' + selected_component.upper() + '): ' + add_for_title), colors = colors, label = 'relatively low potential                                                                           relatively high potential', monitoring_potential = True,  output=output, pngfile = pngfile, extend = 'max', extended = extended)
 
             file_path = os.path.join(output, pngfile + '.png')
             if os.path.exists(file_path):
@@ -1612,7 +1615,7 @@ def monitoring_potential_maps(nwc, country, extended = False):
             pngfile = name_underscore + '_monitoring_potential' + country.replace(' ', '_')
             
             if (abs(footprint_even)-abs(footprint)).max() > 0.0000001:
-                plot_maps_country_zoom(abs(footprint_even)-abs(footprint), load_lon, load_lat, nwc, country, title = (name + ' monitoring potential ' + country_name + ' ' + add_for_title), colors = colors,label = 'relatively low potential                                                                           relatively high potential', monitoring_potential = True, output=output, pngfile = pngfile, extend='max', extended = extended)
+                plot_maps_country_zoom(abs(footprint_even)-abs(footprint), load_lon, load_lat, nwc, country, title = (name + ' monitoring potential (' + selected_component.upper() + ') ' + country_name + ': ' + add_for_title), colors = colors,label = 'relatively low potential                                                                           relatively high potential', monitoring_potential = True, output=output, pngfile = pngfile, extend='max', extended = extended)
 
                 file_path = os.path.join(output, pngfile + '.png')
                 if os.path.exists(file_path):      
@@ -1624,7 +1627,7 @@ def monitoring_potential_maps(nwc, country, extended = False):
             
                     display(HTML('<p style="font-size:15px">Due to our definition of monitoring potential, the improved monitoring of ' +  name + ' in ' + country_name + ' is almost infinite in the extended network compared to the current network.  To see the monitoring potential of the extended network, select it when prompted for "Network name" in section 3.2. and run the tool without extension.</p>'))
                     # if GEE has infinate improved monitoring potential, there will be no maps for the different land cover types. 
-                    if name == 'GEE':
+                    if name == 'GEE' or name == 'Respiration':
                         return
                 else:
                     display(HTML('<p style="font-size:15px">Sensing of ' +  name +' in ' + country_name + ' is very low and it is not feasible to show monitoring potential of.</p>'))
@@ -1673,9 +1676,9 @@ def signals_table_anthro(stc, output=output, csvfile='anthro_table.csv'):
     
     df_save.to_csv(os.path.join(output, csvfile), index = False)  
 
-
-def signals_table_bio(stc, component='gee', output=output, csvfile='bio_table.csv'):   
     
+def signals_table_bio(stc, component='gee', output=output, csvfile='bio_table.csv'):   
+    component = stc['component']
     stations = stc['signalsStations']
     timeselect_list = stc['timeOfDay']
     
@@ -1696,11 +1699,13 @@ def signals_table_bio(stc, component='gee', output=output, csvfile='bio_table.cs
 
     broad_leaf_forest, coniferous_forest, mixed_forest, ocean, other, grass_shrub, cropland, pasture, urban, unknown = import_landcover_HILDA(year='2018')
 
-    list_classes_names = ['broad_leaf_forest', 'coniferous_forest', 'mixed_forest', 'ocean', 'other', 'grass_shrub', 'cropland', \
-                          'pasture', 'urban', 'unknown']
+    #ocean, other, unknown are fractional grids put into "other" derived from the total. 
+    list_classes_names = ['broad_leaf_forest', 'coniferous_forest', 'mixed_forest', 'grass_shrub', 'cropland', \
+                          'pasture', 'urban']
 
-    list_classes_km2 = [broad_leaf_forest, coniferous_forest, mixed_forest, ocean, other, grass_shrub, cropland, \
-                        pasture, urban, unknown]
+    list_classes_km2 = [broad_leaf_forest, coniferous_forest, mixed_forest, grass_shrub, cropland, \
+                        pasture, urban]
+        
 
     # want vegetation fraction HILDA land cover maps (as opposed to km2 for the entire cell - "list_classes_km2")
     list_landcover_fractions = []
@@ -1711,8 +1716,9 @@ def signals_table_bio(stc, component='gee', output=output, csvfile='bio_table.cs
 
         list_landcover_fractions.append(landcover_fraction)
 
-    df_save = pd.DataFrame(columns= ['Station',
-                                    'GEE total', 'GEE total (STILT)*','Broad leaf forest (GEE)', 'Coniferous forest (GEE)', 'Mixed forest (GEE)','Ocean (GEE)','Other (GEE)','Grass and shrub (GEE)', 'Cropland (GEE)','Pasture (GEE)','Urban (GEE)', 'Unknown (GEE)'])
+    df_save = pd.DataFrame(columns= ['Station', component + ' total', component + ' total (STILT)*','Broad leaf forest (' + component + ')', 'Coniferous forest (' + component + ')', 'Mixed forest (' + component + ')',\
+                                     'Grass and shrub (' + component + ')', 'Cropland (' + component + ')','Pasture (' + component + ')',\
+                                     'Urban (' + component + ')', 'Other (' + component + ')'])
 
     # index for putting the data for each station (mean) in the correct place in the dataframe "df_save"
     i_outer = 0
@@ -1723,7 +1729,11 @@ def signals_table_bio(stc, component='gee', output=output, csvfile='bio_table.cs
         df_stilt_result_only_numeber = df_stilt_result.select_dtypes(['number'])
 
         average_df_stilt_result = df_stilt_result_only_numeber.mean()
-        gee_station_stilt = abs(average_df_stilt_result['co2.bio.gee'])
+        
+        if component == 'GEE':
+            component_station_stilt = abs(average_df_stilt_result['co2.bio.gee'])
+        else:
+            component_station_stilt = abs(average_df_stilt_result['co2.bio.resp'])
         
         i = 0 
 
@@ -1735,23 +1745,28 @@ def signals_table_bio(stc, component='gee', output=output, csvfile='bio_table.cs
         for date in date_range:
 
             # access the correct VPRM flux dataset
-            if first or date.year!=current_year:
+            if first or date.month!=current_month:
 
                 current_year = date.year
                 
-                filename_gee = check_cp(path_cp,'VPRM_ECMWF_GEE_' + str(current_year) + '_CP.nc')
+                current_month = date.month
+                
+                if component == 'GEE':
+                    filename_component = '/data/project/obsnet/VPRM_10day/gee/GEE_10day_' +str(current_year) + '_' + str(current_month) + '.nc'
+                else:
+                    filename_component = '/data/project/obsnet/VPRM_10day/respiration/RESP_10day_' +str(current_year) + '_' + str(current_month) + '.nc'
 
-                f_gee = cdf.Dataset(filename_gee)
-
-                times = f_gee.variables['time']
+                f_component = xr.open_dataset(filename_component)
 
                 first = False
 
             date_string = str(date.year) + '-' + str(date.month) + '-' + str(date.day) + ' ' +  str(date.hour)
 
-            ntime = date2index(date,times,select='nearest')
-
-            gee = f_gee.variables['GEE'][ntime][:][:]
+            if component == 'GEE':
+                
+                component_selected = f_component.sel(time=date).gee_10day.data
+            else:
+                component_selected = f_component.sel(time=date).resp_10day.data
 
             filename=(pathFP+station+'/'+str(date.year)+'/'+str(date.month).zfill(2)+'/'
                  +str(date.year)+'x'+str(date.month).zfill(2)+'x'+str(date.day).zfill(2)+'x'+str(date.hour).zfill(2)+'/foot')
@@ -1761,53 +1776,65 @@ def signals_table_bio(stc, component='gee', output=output, csvfile='bio_table.cs
                 f_fp = cdf.Dataset(filename)
                 fp=f_fp.variables['foot'][:,:,:]
 
-                fp_gee_station = abs(gee) * fp
+                fp_component_station = abs(component_selected) * fp
                 
                 if first_average: 
 
-                    fp_gee_station_average = fp_gee_station
+                    fp_component_station_average = fp_component_station
                     
                     first_average = False
                     
                 else:
 
-                    fp_gee_station_average = fp_gee_station_average + fp_gee_station
+                    fp_component_station_average = fp_component_station_average + fp_component_station
                     
                 i = i + 1
 
-        fp_gee_station_average = fp_gee_station_average / i 
+        fp_component_station_average = fp_component_station_average / i 
         
-        average_gee = fp_gee_station_average.sum()
+        average_component = fp_component_station_average.sum()
 
         # to be extended with land cover data
-        data_row = [station, average_gee, gee_station_stilt]
+        data_row = [station, average_component, component_station_stilt]
 
+        other_fluxes = average_component
         for landcover_fraction in list_landcover_fractions:
 
-            fp_gee_station_landcover = (fp_gee_station_average * landcover_fraction).sum()
+            fp_component_station_landcover = (fp_component_station_average * landcover_fraction).sum()
      
-            data_row.extend([fp_gee_station_landcover])
+            data_row.extend([fp_component_station_landcover])
+        
+            other_fluxes = other_fluxes - fp_component_station_landcover
 
-        df_save.loc[i_outer] = data_row
+        df_save.loc[i_outer] = data_row + [other_fluxes]
 
         i_outer = i_outer + 1
         f.value+=1
         
     df_save_sort = df_save.sort_values(by=['Station'])
     
-    df_save_subset_gee = df_save_sort[['Station',  'Broad leaf forest (GEE)', 'Coniferous forest (GEE)', 'Mixed forest (GEE)', 'Other (GEE)',  'Grass and shrub (GEE)',  'Cropland (GEE)',  'Pasture (GEE)',  'Urban (GEE)', 'GEE total', 'GEE total (STILT)*']]
+    df_save_subset_component = df_save_sort[['Station',  'Broad leaf forest (' + component + ')', 'Coniferous forest (' + component + ')', 'Mixed forest (' + component + ')', \
+                                            'Grass and shrub (' + component + ')',  'Cropland (' + component + ')',  'Pasture (' + component + ')',\
+                                             'Urban (' + component + ')', 'Other (' + component + ')', component + ' total', component +' total (STILT)*']]
 
-    subset_style = ['Broad leaf forest (GEE)', 'Coniferous forest (GEE)', 'Mixed forest (GEE)', 'Other (GEE)',  'Grass and shrub (GEE)',  'Cropland (GEE)',  'Pasture (GEE)',  'Urban (GEE)']
-    subset_format = {key: "{:.2f}" for key in subset_style}
-    subset_format['GEE total'] = '{:.2f}'
-    subset_format['GEE total (STILT)*'] = '{:.2f}'
-
-    df_save_sort_styled = df_save_subset_gee.style.background_gradient(cmap = 'Greens', axis=None, subset = subset_style)\
-                                      .format(subset_format)
-
-    display(df_save_sort_styled)
-    df_save.to_csv(os.path.join(output, csvfile), index = False)  
+    subset_style = ['Broad leaf forest (' + component + ')', 'Coniferous forest (' + component + ')', 'Mixed forest (' + component + ')',\
+                    'Grass and shrub (' + component + ')',  'Cropland (' + component + ')',  'Pasture (' + component + ')',  'Urban (' + component + ')','Other (' + component + ')']
     
+    subset_format = {key: "{:.2f}" for key in subset_style}
+    subset_format[component + ' total'] = '{:.2f}'
+    subset_format[component + ' total (STILT)*'] = '{:.2f}'
+    
+    if component == 'GEE':
+
+        df_save_sort_styled = df_save_subset_component.style.background_gradient(cmap = 'Greens', axis=None, subset = subset_style)\
+                                          .format(subset_format)
+    else:
+        
+        df_save_sort_styled = df_save_subset_component.style.background_gradient(cmap = 'Reds', axis=None, subset = subset_style)\
+                                          .format(subset_format)
+    display(df_save_sort_styled)
+    df_save.to_csv(os.path.join(output, csvfile), index = False)
+
 def average_threshold_fp(station, date_range, threshold):
     
     pathFP='/data/stiltweb/stations/'
@@ -1856,10 +1883,12 @@ def initiate_summer_winter_comparison():
         update_button.disabled = False
         update_button.style.button_color=button_color_able
 
-        list_optional_stations = sorted([k for k, v in stilt_stations.items() if str(selected_year) in v['years'] if len(v[str(selected_year)]['months']) == 12])
+        list_optional_stations_located = sorted([((v['geoinfo']['name']['common'] + ': ' + v['name'] + ' ('+ k + ')'),k) for k, v in stilt_stations.items() if str(selected_year) in v['years'] if len(v[str(selected_year)]['months']) == 12 if v['geoinfo']])
+        list_optional_stations_not_located =  [(('In water' + ': ' + v['name'] + ' ('+ k + ')'),k) for k, v in stilt_stations.items() if str(selected_year) in v['years'] if len(v[str(selected_year)]['months']) == 12 if not v['geoinfo']]
+        list_optional_stations = list_optional_stations_located + list_optional_stations_not_located
 
         specific_station_choice.options = list_optional_stations
-        specific_station_choice.value = list_optional_stations[0]
+        specific_station_choice.value = list_optional_stations[0][1]
         
     
     def update_func(button_c):
@@ -1894,7 +1923,7 @@ def initiate_summer_winter_comparison():
         with landcover_bar: 
             
             land_cover_bar_graph_winter_summer(stc, output=output, pngfile='landcover_summer_winter.png')
-            display(HTML('<p style="font-size:15px;"><b>Figure 2b: Land cover shares within the summer (JJA) and winter (JFD) footprints split by direction. Bars representing summer are on the left and bars representing winter on the right. The summer and winter sums of percentages are shown in the legend.</b></p>'))
+            display(HTML('<p style="font-size:15px;"><b>Figure 2b: Land cover shares weighed by the seasonal footprints split by direction. Bars representing summer are on the left and bars representing winter on the right.</b></p>'))
 
             file_path = os.path.join(output, 'landcover_summer_winter.png')
 
@@ -2028,8 +2057,8 @@ def contour_map_summer_winter(stc, output=output, pngfile='contour_summer_winter
     average_fp_winter = read_aggreg_footprints(station, date_range_winter)
     f.value += 1
     
-    average_fp_summer = update_footprint_based_on_threshold(average_fp_summer, 0.5)
-    average_fp_winter = update_footprint_based_on_threshold(average_fp_winter, 0.5)
+    average_fp_summer = update_footprint_based_on_threshold(average_fp_summer, threshold)
+    average_fp_winter = update_footprint_based_on_threshold(average_fp_winter, threshold)
     
     list_fps = [average_fp_summer, average_fp_winter]
     
@@ -2114,6 +2143,13 @@ def contour_map_summer_winter(stc, output=output, pngfile='contour_summer_winter
 
     #show station location 
     ax.plot(station_lon,station_lat,'+',color='Blue',ms=5,transform=ccrs.PlateCarree(), label = station_name)
+    
+    # grid
+    gl = ax.gridlines(crs=ccrs.PlateCarree(), draw_labels=True,
+                  linewidth=0.5, color='gray', alpha=0.5)
+    gl.xformatter, gl.yformatter  = LONGITUDE_FORMATTER, LATITUDE_FORMATTER
+    gl.xlabel_style, gl.ylabel_style = {'size': 10, 'color': 'gray', 'alpha':0.5}, {'size': 10, 'color': 'gray', 'alpha':0.5}
+
 
     ax.legend(loc='lower right', fontsize='medium')
 
@@ -2126,7 +2162,7 @@ def contour_map_summer_winter(stc, output=output, pngfile='contour_summer_winter
         if not os.path.exists(output):
             os.makedirs(output)
 
-        fig.savefig(output+'/'+pngfile,dpi=100,bbox_inches='tight')
+        fig.savefig(output+'/'+pngfile,dpi=300,bbox_inches='tight')
 
 def land_cover_bar_graph_winter_summer(stc, output=output, pngfile='landcover_summer_winter.png'): 
     
@@ -2158,10 +2194,10 @@ def land_cover_bar_graph_winter_summer(stc, output=output, pngfile='landcover_su
     else:
         degrees=degrees_from_point_to_grid_cells(station_lat, station_lon, load_lat, load_lon)
 
-
     #get all the land cover data from netcdfs 
     broad_leaf_forest, coniferous_forest, mixed_forest, ocean, other, grass_shrub, cropland, pasture, urban, unknown = import_landcover_HILDA(year='2018')
-    
+
+    # take first out of two date ranges for final graph
     fp = read_aggreg_footprints(station, date_range1)
     
     f.value += 1
@@ -2306,7 +2342,6 @@ def land_cover_bar_graph_winter_summer(stc, output=output, pngfile='landcover_su
 
     df_all2 = df_cropland2.append([df_broad_leaf_forest2, df_coniferous_forest2, df_mixed_forest2, df_ocean2, df_other2, \
                                    df_grass_shrub2, df_pasture2, df_urban2, df_unknown2])
-
     #not change with user input
     dir_bins = np.arange(22.5, 383.5, 45)
     dir_bins= np.asarray([0, 22.5,67.5,112.5,157.5,202.5,247.5,292.5,337.5,383.5])
@@ -2364,30 +2399,44 @@ def land_cover_bar_graph_winter_summer(stc, output=output, pngfile='landcover_su
     # for one land cover type to be displayed in a stacked bar
     # there will be one array per land cover type (10)
     list_land_cover_values=[]
+    list_of_list_totals = []
     for land_cover_type in list_land_cover_names_sorted:
 
         list_date_range1 = rosedata1[land_cover_type].values
         list_date_range2 = rosedata2[land_cover_type].values
+        
+        totals = []
+        
+        totals.append(sum(list_date_range1))
+        totals.append(sum(list_date_range2))
 
         # every second value should be from the 1st date range (summer for instance)
         # and every other value should be from the 2nd date range (winter for instance)
         aggreg_list = []
+        
+        # added:
         for value_date_range1, value_date_range2 in zip(list_date_range1, list_date_range2):
             aggreg_list.append(value_date_range1)
             aggreg_list.append(value_date_range2)
 
         list_land_cover_values.append(np.array(aggreg_list))
+        
+        list_of_list_totals.append(np.array(totals))
 
     matplotlib.rcParams.update({'font.size': 12})
-    fig = plt.figure(figsize=(12,8)) 
+    fig = plt.figure(figsize=(8,8)) 
 
     ax = fig.add_subplot(111)
+    
+    ax2 = ax.twinx()
 
     # space it in a way summer and winter are close.
     ind = np.array([ 0,  0.5,  2,  2.5,  4,  4.5,  6,  6.5,  8,  8.5, 10, 10.5, 12, 12.5, 14, 14.5])
 
+    ind2 = np.array([16,16.5])
+    
     width = 0.35       
-
+    
     # p1 is the first land cover type (with largest share for date range 1).
     # the remaining (9) land cover classes are stacked on top (with the below - "bottom" - land cover types under)
     p1 = ax.bar(ind, list_land_cover_values[0], width, color=dictionary_color[list_land_cover_names_sorted[0]]['color'], edgecolor='black')
@@ -2418,12 +2467,46 @@ def land_cover_bar_graph_winter_summer(stc, output=output, pngfile='landcover_su
     p10 = ax.bar(ind, list_land_cover_values[9], width, color=dictionary_color[list_land_cover_names_sorted[9]]['color'], edgecolor='black', \
                  bottom=list_land_cover_values[0]+list_land_cover_values[1]+list_land_cover_values[2]+list_land_cover_values[3]+\
                  list_land_cover_values[4]+list_land_cover_values[5]+list_land_cover_values[6]+ list_land_cover_values[7]+list_land_cover_values[8])
-
+    
+    
     #want to reverese the order (ex if oceans at the "bottom" in the graph - ocean label should be furthest down)
     handles=(p1[0], p2[0], p3[0], p4[0], p5[0], p6[0], p7[0], p8[0], p9[0])
 
+    # second axis:
+    q1 = ax2.bar(ind2, list_of_list_totals[0], width, color=dictionary_color[list_land_cover_names_sorted[0]]['color'], edgecolor='black')
+
+    q2 = ax2.bar(ind2, list_of_list_totals[1], width, color=dictionary_color[list_land_cover_names_sorted[1]]['color'],edgecolor='black',
+                 bottom=list_of_list_totals[0])
+    q3 = ax2.bar(ind2, list_of_list_totals[2], width, color=dictionary_color[list_land_cover_names_sorted[2]]['color'], edgecolor='black',
+                 bottom=list_of_list_totals[0]+list_of_list_totals[1])
+    q4 = ax2.bar(ind2, list_of_list_totals[3], width, color=dictionary_color[list_land_cover_names_sorted[3]]['color'], edgecolor='black',
+                 bottom=list_of_list_totals[0]+list_of_list_totals[1]+list_of_list_totals[2])
+    q5 = ax2.bar(ind2, list_of_list_totals[4], width, color=dictionary_color[list_land_cover_names_sorted[4]]['color'], edgecolor='black',
+                 bottom=list_of_list_totals[0]+list_of_list_totals[1]+list_of_list_totals[2]+list_of_list_totals[3])
+    q6 = ax2.bar(ind2, list_of_list_totals[5], width, color=dictionary_color[list_land_cover_names_sorted[5]]['color'], edgecolor='black',
+                 bottom=list_of_list_totals[0]+list_of_list_totals[1]+list_of_list_totals[2]+list_of_list_totals[3]+\
+                 list_of_list_totals[4])
+    q7 = ax2.bar(ind2, list_of_list_totals[6], width, color=dictionary_color[list_land_cover_names_sorted[6]]['color'], edgecolor='black',
+                 bottom=list_of_list_totals[0]+list_of_list_totals[1]+list_of_list_totals[2]+list_of_list_totals[3]+\
+                 list_of_list_totals[4]+list_of_list_totals[5])
+
+    q8 = ax2.bar(ind2, list_of_list_totals[7], width, color=dictionary_color[list_land_cover_names_sorted[7]]['color'], edgecolor='black', 
+                bottom=list_of_list_totals[0]+list_of_list_totals[1]+list_of_list_totals[2]+list_of_list_totals[3]+\
+                 list_of_list_totals[4]+list_of_list_totals[5]+list_of_list_totals[6])
+
+    q9 = ax2.bar(ind2, list_of_list_totals[8], width, color=dictionary_color[list_land_cover_names_sorted[8]]['color'], edgecolor='black', \
+                bottom=list_of_list_totals[0]+list_of_list_totals[1]+list_of_list_totals[2]+list_of_list_totals[3]+\
+                 list_of_list_totals[4]+list_of_list_totals[5]+list_of_list_totals[6]+list_of_list_totals[7])
+
+    q10 = ax2.bar(ind2, list_of_list_totals[9], width, color=dictionary_color[list_land_cover_names_sorted[9]]['color'], edgecolor='black', \
+                 bottom=list_of_list_totals[0]+list_of_list_totals[1]+list_of_list_totals[2]+list_of_list_totals[3]+\
+                 list_of_list_totals[4]+list_of_list_totals[5]+list_of_list_totals[6]+ list_of_list_totals[7]+list_of_list_totals[8])
+
     index=0
-    list_labels=[]
+    list_labels= []
+    
+    list_summer= []
+    list_winter = []
     for land_cover_name in list_land_cover_names_sorted:
 
         # date ramge 1 and 2 (summer and winter), sum every second (how the data is stored - 16 (8 directions x2) 
@@ -2432,21 +2515,35 @@ def land_cover_bar_graph_winter_summer(stc, output=output, pngfile='landcover_su
         if not land_cover_name == 'Unknown':
         
             list_labels.append(for_lable)
-        index=index+1
 
+        index=index+1
+        
     labels=[textwrap.fill(text,25) for text in list_labels]
 
+
     #other way - smallest in legend up top which is how 
-    plt.legend(handles[::-1], labels[::-1],bbox_to_anchor=(1, 0.56), title = "     Summer (%), Winter (%)")
+    #plt.legend(handles[::-1], labels[::-1], title = "         Summer (%), Winter (%)")#,bbox_to_anchor=(1, 0.56)
+        #other way - smallest in legend up top which is how 
+    # first one - second one I 
+    plt.legend(handles[::-1], labels[::-1],bbox_to_anchor=(1, 0.4), title = "     Summer (%), Winter (%)")
 
-    plt.ylabel('%')
+    
+    # set it to + 10 and round it to closest 10th
+    y_max = int(math.ceil((ax.get_ylim()[1]) / 10.0)) * 10
+    ax.set_ylim([0, y_max])
+    ax2.set_ylim([0, 100])
 
+    #plt.ylabel('%')
+    ax.set_ylabel('Share direction (%)')
+    ax2.set_ylabel('Share total (%)')
+    
     #first one is not north (in rosedata - rather 22.5 to 67.5 (NE).
     # two values (date range 1 and 2) for each direction
-    plt.xticks(ind, ('N', 'E','   E','','S','E', '   S',  '', 'S','W','   W', '','N', 'W','   N',''))
+    plt.xticks(np.concatenate((ind, ind2), axis=None), ('N', 'E','   E','','S','E', '    S',  '', 'S','W','    W', '','N', 'W','    N','', 'TOT', '   AL'))
+
     ax.yaxis.grid(True)
 
-    fig.set_size_inches(11, 13)
+    #fig.set_size_inches(11, 13)
     
     plt.show()
     if len(pngfile)>0:
@@ -2456,7 +2553,7 @@ def land_cover_bar_graph_winter_summer(stc, output=output, pngfile='landcover_su
         if not os.path.exists(output):
             os.makedirs(output)
   
-        fig.savefig(output+'/'+pngfile,dpi=100,bbox_inches='tight')
+        fig.savefig(output+'/'+pngfile,dpi=300,bbox_inches='tight')
     
     f.value += 1
     plt.close()


### PR DESCRIPTION
Note that some of these changes only work on the new image (including the upload of settings). 

- upload settings had to be changed (not need to convert to bytes anymore). Applies to all notebooks that has the option to upload settings.

- gui_stilt update (for the radiocarbon notebook):

update to "change_year" trigger.
"setting" e_year too early meant the triggering of "change_yr_end" which tryied to access the set start month values. However, the start month values were not set yet. Strange that this works on exploredata now...

Other, more general updates:
- updated date range option for the network characterization (now there are footprints for 2021 also)
- "check" the date range to enable/disable "run selection" button. Same way in all notebooks.
- updated function in the network-view tool (network_analysis_functions). It caused the kernel to die on exploretest. Now I am overwriting variables after they are not needed anymore.