### PR TITLE
updates tested - revert changes to upload settings

### DIFF
--- a/notebooks/icos_jupyter_notebooks/network_characterization/gui_network_characterization.py
+++ b/notebooks/icos_jupyter_notebooks/network_characterization/gui_network_characterization.py
@@ -273,11 +273,16 @@ def file_set_widgets(c):
     
     uploaded_file = file_name.value
     
-    if bool(uploaded_file):
-        
-        settings_file=uploaded_file[list(uploaded_file.keys())[0]]['content']
-        settings_json = settings_file.decode('utf8').replace("'", '"')
-        settings_dict = json.loads(settings_json)
+    # if the content of the file is loaded as a dictionary or tuple depends on the version of ipywidgets
+    # dictionary
+    if isinstance(uploaded_file, dict):
+        settings_file = uploaded_file[list(uploaded_file.keys())[0]]['content']
+        settings_dict = json.loads(settings_file)
+        set_settings(settings_dict)
+    # tulple
+    else:
+        settings_content = uploaded_file[0]['content'].tobytes()
+        settings_dict = json.loads(settings_content)
         set_settings(settings_dict)
 
 def change_yr(c):

--- a/notebooks/icos_jupyter_notebooks/network_characterization/gui_network_characterization.py
+++ b/notebooks/icos_jupyter_notebooks/network_characterization/gui_network_characterization.py
@@ -272,19 +272,12 @@ def change_selected_countries(c):
 def file_set_widgets(c):
     
     uploaded_file = file_name.value
-
-    #check if there is content in the dictionary (uploaded file)
-    if type(uploaded_file) is tuple:
-            # unless tobytes() is used, settings_concent will be of type "memoryview"
-            settings_content = uploaded_file[0]['content'].tobytes()
-            settings_dict = json.loads(settings_content)
-            set_settings(settings_dict)
-
-    #this works on exploredata (uploaded_file = dictionary)
-    else:
+    
+    if bool(uploaded_file):
+        
         settings_file=uploaded_file[list(uploaded_file.keys())[0]]['content']
         settings_json = settings_file.decode('utf8').replace("'", '"')
-        settings_dict = json.loads(settings_file.tobytes())
+        settings_dict = json.loads(settings_json)
         set_settings(settings_dict)
 
 def change_yr(c):

--- a/notebooks/icos_jupyter_notebooks/network_characterization/gui_network_characterization.py
+++ b/notebooks/icos_jupyter_notebooks/network_characterization/gui_network_characterization.py
@@ -270,20 +270,19 @@ def change_selected_countries(c):
     selected_countries.options = [o for o in selected_countries.options if o not in list_tuple]
 
 def file_set_widgets(c):
-    
+
     uploaded_file = file_name.value
-    
-    # if the content of the file is loaded as a dictionary or tuple depends on the version of ipywidgets
-    # dictionary
+
+    # If the content of the file is loaded as a dictionary or tuple
+    # depends on the version of ipywidgets.
+    # Case of Dictionary.
     if isinstance(uploaded_file, dict):
-        settings_file = uploaded_file[list(uploaded_file.keys())[0]]['content']
-        settings_dict = json.loads(settings_file)
-        set_settings(settings_dict)
-    # tulple
+        settings_content = uploaded_file[list(uploaded_file.keys())[0]]['content']
+    # Case of Tuple.
     else:
         settings_content = uploaded_file[0]['content'].tobytes()
-        settings_dict = json.loads(settings_content)
-        set_settings(settings_dict)
+    settings_dict = json.loads(settings_content)
+    set_settings(settings_dict)
 
 def change_yr(c):
     

--- a/notebooks/icos_jupyter_notebooks/radiocarbon/gui_stilt.py
+++ b/notebooks/icos_jupyter_notebooks/radiocarbon/gui_stilt.py
@@ -291,12 +291,18 @@ def file_set_widgets(c):
     
     uploaded_file = file_name.value
     
-    if bool(uploaded_file):
-        
-        settings_file=uploaded_file[list(uploaded_file.keys())[0]]['content']
-        settings_json = settings_file.decode('utf8').replace("'", '"')
-        settings_dict = json.loads(settings_json)
+    # if the content of the file is loaded as a dictionary or tuple depends on the version of ipywidgets
+    # dictionary
+    if isinstance(uploaded_file, dict):
+        settings_file = uploaded_file[list(uploaded_file.keys())[0]]['content']
+        settings_dict = json.loads(settings_file)
         set_settings(settings_dict)
+    # tulple
+    else:
+        settings_content = uploaded_file[0]['content'].tobytes()
+        settings_dict = json.loads(settings_content)
+        set_settings(settings_dict)
+        
 #----------- start processing -----------------
 
 def updateProgress(f, desc=''):

--- a/notebooks/icos_jupyter_notebooks/radiocarbon/gui_stilt.py
+++ b/notebooks/icos_jupyter_notebooks/radiocarbon/gui_stilt.py
@@ -288,20 +288,19 @@ def change_facility_choice(c):
         threshold_facility_inclusions.disabled = True
         
 def file_set_widgets(c):
-    
+
     uploaded_file = file_name.value
-    
-    # if the content of the file is loaded as a dictionary or tuple depends on the version of ipywidgets
-    # dictionary
+
+    # If the content of the file is loaded as a dictionary or tuple
+    # depends on the version of ipywidgets.
+    # Case of Dictionary.
     if isinstance(uploaded_file, dict):
-        settings_file = uploaded_file[list(uploaded_file.keys())[0]]['content']
-        settings_dict = json.loads(settings_file)
-        set_settings(settings_dict)
-    # tulple
+        settings_content = uploaded_file[list(uploaded_file.keys())[0]]['content']
+    # Case of Tuple.
     else:
         settings_content = uploaded_file[0]['content'].tobytes()
-        settings_dict = json.loads(settings_content)
-        set_settings(settings_dict)
+    settings_dict = json.loads(settings_content)
+    set_settings(settings_dict)
         
 #----------- start processing -----------------
 

--- a/notebooks/icos_jupyter_notebooks/radiocarbon/gui_stilt.py
+++ b/notebooks/icos_jupyter_notebooks/radiocarbon/gui_stilt.py
@@ -291,18 +291,11 @@ def file_set_widgets(c):
     
     uploaded_file = file_name.value
     
-    #check if there is content in the dictionary (uploaded file)
-    if type(uploaded_file) is tuple:
-            # unless tobytes() is used, settings_concent will be of type "memoryview"
-            settings_content = uploaded_file[0]['content'].tobytes()
-            settings_dict = json.loads(settings_content)
-            set_settings(settings_dict)
-
-    #this works on exploredata (uploaded_file = dictionary)
-    else:
+    if bool(uploaded_file):
+        
         settings_file=uploaded_file[list(uploaded_file.keys())[0]]['content']
         settings_json = settings_file.decode('utf8').replace("'", '"')
-        settings_dict = json.loads(settings_file.tobytes())
+        settings_dict = json.loads(settings_json)
         set_settings(settings_dict)
 #----------- start processing -----------------
 

--- a/notebooks/icos_jupyter_notebooks/station_characterization/gui.py
+++ b/notebooks/icos_jupyter_notebooks/station_characterization/gui.py
@@ -266,15 +266,21 @@ def change_day_end(c):
     check_date_range()
         
 def file_set_widgets(c):
-    
+
     uploaded_file = file_name.value
     
-    if bool(uploaded_file):
-        
-        settings_file=uploaded_file[list(uploaded_file.keys())[0]]['content']
-        settings_json = settings_file.decode('utf8').replace("'", '"')
-        settings_dict = json.loads(settings_json)
+    # if the content of the file is loaded as a dictionary or tuple depends on the version of ipywidgets
+    # dictionary
+    if isinstance(uploaded_file, dict):
+        settings_file = uploaded_file[list(uploaded_file.keys())[0]]['content']
+        settings_dict = json.loads(settings_file)
         set_settings(settings_dict)
+    # tulple
+    else:
+        settings_content = uploaded_file[0]['content'].tobytes()
+        settings_dict = json.loads(settings_content)
+        set_settings(settings_dict)
+
 #----------- start processing -----------------
      
 def updateProgress(f, desc=''):

--- a/notebooks/icos_jupyter_notebooks/station_characterization/gui.py
+++ b/notebooks/icos_jupyter_notebooks/station_characterization/gui.py
@@ -269,18 +269,11 @@ def file_set_widgets(c):
     
     uploaded_file = file_name.value
     
-    #check if there is content in the dictionary (uploaded file)
-    if type(uploaded_file) is tuple:
-            # unless tobytes() is used, settings_concent will be of type "memoryview"
-            settings_content = uploaded_file[0]['content'].tobytes()
-            settings_dict = json.loads(settings_content)
-            set_settings(settings_dict)
-
-    #this works on exploredata (uploaded_file = dictionary)
-    else:
+    if bool(uploaded_file):
+        
         settings_file=uploaded_file[list(uploaded_file.keys())[0]]['content']
         settings_json = settings_file.decode('utf8').replace("'", '"')
-        settings_dict = json.loads(settings_file.tobytes())
+        settings_dict = json.loads(settings_json)
         set_settings(settings_dict)
 #----------- start processing -----------------
      

--- a/notebooks/icos_jupyter_notebooks/station_characterization/gui.py
+++ b/notebooks/icos_jupyter_notebooks/station_characterization/gui.py
@@ -268,18 +268,17 @@ def change_day_end(c):
 def file_set_widgets(c):
 
     uploaded_file = file_name.value
-    
-    # if the content of the file is loaded as a dictionary or tuple depends on the version of ipywidgets
-    # dictionary
+
+    # If the content of the file is loaded as a dictionary or tuple
+    # depends on the version of ipywidgets.
+    # Case of Dictionary.
     if isinstance(uploaded_file, dict):
-        settings_file = uploaded_file[list(uploaded_file.keys())[0]]['content']
-        settings_dict = json.loads(settings_file)
-        set_settings(settings_dict)
-    # tulple
+        settings_content = uploaded_file[list(uploaded_file.keys())[0]]['content']
+    # Case of Tuple.
     else:
         settings_content = uploaded_file[0]['content'].tobytes()
-        settings_dict = json.loads(settings_content)
-        set_settings(settings_dict)
+    settings_dict = json.loads(settings_content)
+    set_settings(settings_dict)
 
 #----------- start processing -----------------
      


### PR DESCRIPTION
Revert to the changes to function "file_set_widgets" (setting widgets upon uploading a file) in commit "updates to work on new release / images". In my last commit I had reverted these changes as the updated "file_set_widgets" did not seem to work on exploretest.