### PR TITLE
Minor updates (into + name of output)

### DIFF
--- a/notebooks/icos_jupyter_notebooks/ecosystem_site_anomaly_visualization.ipynb
+++ b/notebooks/icos_jupyter_notebooks/ecosystem_site_anomaly_visualization.ipynb
@@ -4,10 +4,10 @@
    "cell_type": "markdown",
    "id": "70169600-1ab2-44ba-b3ee-e19a5c6f0534",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%% md\n"
-    }
+    },
+    "tags": []
    },
    "source": [
     "<p float=\"left\">\n",
@@ -23,7 +23,7 @@
     "\n",
     "#### Notebook Citation\n",
     "\n",
-    "Storm, I., Klasen, V., 2023. Ecosystem Site Anomaly Visualization Notebook Tool. ICOS ERIC - Carbon Portal. https://doi.org/10.18160/AMET-9KWT\n",
+    "Storm, I., Klasen, V., 2023. Ecosystem Site Anomaly Visualization Notebook Tool. ICOS ERIC - Carbon Portal. https://doi.org/10.18160/Q10G-9CTJ\n",
     "\n",
     "### Flux data \n",
     "\n",

--- a/notebooks/icos_jupyter_notebooks/ecosystem_site_anomaly_visualization/plot_interface_anomaly.py
+++ b/notebooks/icos_jupyter_notebooks/ecosystem_site_anomaly_visualization/plot_interface_anomaly.py
@@ -401,7 +401,7 @@ def make_plot_anomalies(df,
         output_b[0].savefig(file_path)
 
         if os.path.exists(file_path):
-            html_string = '<br>Access figure for site a <a href=' + relative_file_path + ' target="_blank">here</a>.'
+            html_string = 'Access figure for site b <a href=' + relative_file_path + ' target="_blank">here</a>.'
             display(HTML('<p style="font-size:16px">' +  html_string))
 
     # link to the csv-file (already saved in gui_anomaly)


### PR DESCRIPTION
- The intro had the wrong doi link to the notebook package
- Links to figures with the output were both - in case of two sites selected - called "site a" ("access figure for site a here"). Link were correct, but the second figure is that of "site b" ("access figure for site b here").